### PR TITLE
Config file: schema, parser, validation (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "@mariozechner/pi-coding-agent": ">=0.70.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1"
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "ajv": "^8.17.1"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "typescript": "^5.9.2"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,10 +156,13 @@ function ENDPOINT_MODE() {
 	} as const;
 }
 
+// useDefaults is intentionally OFF: ajv v8 doesn't reliably fill defaults
+// inside oneOf branches, so the manual fallbacks in normalizeServer() are
+// the single source of truth. The schema's `default` annotations remain
+// for documentation / external tooling but aren't load-bearing.
 const ajv = new Ajv2020.default({
 	strict: false,
 	allErrors: true,
-	useDefaults: true,
 });
 
 const validateConfig = ajv.compile(MCPAQL_CONFIG_SCHEMA);
@@ -172,9 +175,9 @@ export async function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Prom
 		notices: [],
 	};
 
-	let raw: string;
+	let fileContent: string;
 	try {
-		raw = await readFile(configPath, "utf8");
+		fileContent = await readFile(configPath, "utf8");
 	} catch (err) {
 		if (isNodeError(err) && err.code === "ENOENT") {
 			result.notices.push(`No config file at ${configPath} (skipping; create one to wire servers).`);
@@ -188,7 +191,7 @@ export async function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Prom
 
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		parsed = JSON.parse(fileContent);
 	} catch (err) {
 		throw new ConfigError(
 			`Malformed JSON in ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
@@ -222,8 +225,8 @@ export async function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Prom
 		seen.add(name);
 	}
 
-	for (const raw of config.servers) {
-		result.servers.push(normalizeServer(raw, result.notices));
+	for (const entry of config.servers) {
+		result.servers.push(normalizeServer(entry, result.notices));
 	}
 
 	result.loaded = true;
@@ -264,16 +267,18 @@ function normalizeServer(
 	};
 }
 
-const ENV_INTERP_RE = /\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}/g;
-
 function expandEnvMap(
 	source: Record<string, string>,
 	serverName: string,
 	notices: string[],
 ): Record<string, string> {
 	const out: Record<string, string> = {};
+	// Constructed fresh per call so any future call sites using exec()/test()
+	// don't trip over a shared lastIndex. The `g` flag is required for
+	// String#replace to substitute every occurrence in a value.
+	const interpRe = /\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}/g;
 	for (const [key, value] of Object.entries(source)) {
-		out[key] = value.replace(ENV_INTERP_RE, (_match, varName: string) => {
+		out[key] = value.replace(interpRe, (_match, varName: string) => {
 			const resolved = process.env[varName];
 			if (resolved === undefined) {
 				notices.push(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,292 @@
+/**
+ * Config loader for ~/.pi/mcpaql.config.json.
+ *
+ * Reads the JSON file, validates against MCPAQL_CONFIG_SCHEMA via ajv,
+ * applies defaults (trust="user", endpointMode="multi", transport="stdio"),
+ * expands ${env:VAR} interpolations in env values, and returns a normalized
+ * ResolvedServerConfig[].
+ *
+ * Soft-fails when the file is missing (returns empty servers with a notice).
+ * Throws with actionable messages on hard failures (malformed JSON, schema
+ * violation) so the entrypoint can surface them via ctx.ui.notify.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import Ajv2020 from "ajv/dist/2020.js";
+
+export type TrustLevel = "untrusted" | "user" | "developer" | "admin";
+export type EndpointMode = "multi" | "unified";
+
+export interface ResolvedDirectConfig {
+	kind: "direct";
+	name: string;
+	transport: "stdio";
+	trust: TrustLevel;
+	endpointMode: EndpointMode;
+	command: string;
+	args: string[];
+	env: Record<string, string>;
+}
+
+export interface ResolvedAdapterConfig {
+	kind: "adapter";
+	name: string;
+	transport: "stdio";
+	trust: TrustLevel;
+	endpointMode: EndpointMode;
+	adapter: string;
+	env: Record<string, string>;
+}
+
+export type ResolvedServerConfig = ResolvedDirectConfig | ResolvedAdapterConfig;
+
+export interface LoadResult {
+	/** Absolute path that was read (or attempted). */
+	configPath: string;
+	/** Whether the file existed and was loaded. */
+	loaded: boolean;
+	/** Validated, defaulted, interpolated server configs. */
+	servers: ResolvedServerConfig[];
+	/** Soft notices (file missing, env var unset). Surface to the user. */
+	notices: string[];
+}
+
+export class ConfigError extends Error {
+	constructor(
+		message: string,
+		readonly configPath: string,
+	) {
+		super(message);
+		this.name = "ConfigError";
+	}
+}
+
+export const DEFAULT_CONFIG_PATH = join(homedir(), ".pi", "mcpaql.config.json");
+
+export const MCPAQL_CONFIG_SCHEMA = {
+	$schema: "https://json-schema.org/draft/2020-12/schema",
+	$id: "https://mcpaql.org/schemas/mcpaql-config.schema.json",
+	title: "MCP-AQL pi-bridge config",
+	type: "object",
+	additionalProperties: false,
+	required: ["servers"],
+	properties: {
+		servers: {
+			type: "array",
+			items: {
+				oneOf: [
+					{
+						type: "object",
+						title: "Direct server (talks MCP-AQL natively)",
+						additionalProperties: false,
+						required: ["name", "direct", "command"],
+						properties: {
+							name: SERVER_NAME(),
+							transport: TRANSPORT(),
+							direct: { const: true },
+							command: { type: "string", minLength: 1 },
+							args: { type: "array", items: { type: "string" } },
+							env: ENV_MAP(),
+							trust: TRUST(),
+							endpointMode: ENDPOINT_MODE(),
+						},
+					},
+					{
+						type: "object",
+						title: "Adapter server (wrapped via @mcpaql/adapter-generator output)",
+						additionalProperties: false,
+						required: ["name", "adapter"],
+						properties: {
+							name: SERVER_NAME(),
+							transport: TRANSPORT(),
+							adapter: { type: "string", minLength: 1 },
+							env: ENV_MAP(),
+							trust: TRUST(),
+							endpointMode: ENDPOINT_MODE(),
+						},
+					},
+				],
+			},
+		},
+	},
+} as const;
+
+function SERVER_NAME() {
+	return {
+		type: "string",
+		pattern: "^[a-z][a-z0-9_]*$",
+		description:
+			"Identifier used for tool naming (snake_case, must start with a lowercase letter).",
+	} as const;
+}
+
+function TRANSPORT() {
+	return {
+		type: "string",
+		enum: ["stdio"],
+		default: "stdio",
+	} as const;
+}
+
+function ENV_MAP() {
+	return {
+		type: "object",
+		additionalProperties: { type: "string" },
+		description:
+			"Environment variables passed to the spawned server. Values may include ${env:VAR} substitutions.",
+	} as const;
+}
+
+function TRUST() {
+	return {
+		type: "string",
+		enum: ["untrusted", "user", "developer", "admin"],
+		default: "user",
+	} as const;
+}
+
+function ENDPOINT_MODE() {
+	return {
+		type: "string",
+		enum: ["multi", "unified"],
+		default: "multi",
+	} as const;
+}
+
+const ajv = new Ajv2020.default({
+	strict: false,
+	allErrors: true,
+	useDefaults: true,
+});
+
+const validateConfig = ajv.compile(MCPAQL_CONFIG_SCHEMA);
+
+export async function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Promise<LoadResult> {
+	const result: LoadResult = {
+		configPath,
+		loaded: false,
+		servers: [],
+		notices: [],
+	};
+
+	let raw: string;
+	try {
+		raw = await readFile(configPath, "utf8");
+	} catch (err) {
+		if (isNodeError(err) && err.code === "ENOENT") {
+			result.notices.push(`No config file at ${configPath} (skipping; create one to wire servers).`);
+			return result;
+		}
+		throw new ConfigError(
+			`Failed to read ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+			configPath,
+		);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		throw new ConfigError(
+			`Malformed JSON in ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+			configPath,
+		);
+	}
+
+	if (!validateConfig(parsed)) {
+		const errs = (validateConfig.errors ?? [])
+			.map((e) => `  ${e.instancePath || "(root)"} ${e.message}${e.params ? ` ${JSON.stringify(e.params)}` : ""}`)
+			.join("\n");
+		throw new ConfigError(
+			`Schema validation failed for ${configPath}:\n${errs}`,
+			configPath,
+		);
+	}
+
+	const config = parsed as { servers: Array<Record<string, unknown>> };
+
+	// Reject duplicate names early — the LLM-side tool registry uses these as
+	// prefixes, and collisions would silently overwrite tools.
+	const seen = new Set<string>();
+	for (const s of config.servers) {
+		const name = String(s.name);
+		if (seen.has(name)) {
+			throw new ConfigError(
+				`Duplicate server name "${name}" in ${configPath}; each server must have a unique name.`,
+				configPath,
+			);
+		}
+		seen.add(name);
+	}
+
+	for (const raw of config.servers) {
+		result.servers.push(normalizeServer(raw, result.notices));
+	}
+
+	result.loaded = true;
+	return result;
+}
+
+function normalizeServer(
+	raw: Record<string, unknown>,
+	notices: string[],
+): ResolvedServerConfig {
+	const name = String(raw.name);
+	const transport = (raw.transport as "stdio" | undefined) ?? "stdio";
+	const trust = (raw.trust as TrustLevel | undefined) ?? "user";
+	const endpointMode = (raw.endpointMode as EndpointMode | undefined) ?? "multi";
+	const env = expandEnvMap((raw.env as Record<string, string> | undefined) ?? {}, name, notices);
+
+	if (raw.direct === true) {
+		return {
+			kind: "direct",
+			name,
+			transport,
+			trust,
+			endpointMode,
+			command: String(raw.command),
+			args: Array.isArray(raw.args) ? (raw.args as string[]) : [],
+			env,
+		};
+	}
+
+	return {
+		kind: "adapter",
+		name,
+		transport,
+		trust,
+		endpointMode,
+		adapter: String(raw.adapter),
+		env,
+	};
+}
+
+const ENV_INTERP_RE = /\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+function expandEnvMap(
+	source: Record<string, string>,
+	serverName: string,
+	notices: string[],
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(source)) {
+		out[key] = value.replace(ENV_INTERP_RE, (_match, varName: string) => {
+			const resolved = process.env[varName];
+			if (resolved === undefined) {
+				notices.push(
+					`Server "${serverName}": env var $${varName} is unset; ${key} will be empty.`,
+				);
+				return "";
+			}
+			return resolved;
+		});
+	}
+	return out;
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+	return err instanceof Error && "code" in err;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,8 +160,21 @@ function ENDPOINT_MODE() {
 // inside oneOf branches, so the manual fallbacks in normalizeServer() are
 // the single source of truth. The schema's `default` annotations remain
 // for documentation / external tooling but aren't load-bearing.
-const ajv = new Ajv2020.default({
-	strict: false,
+//
+// strictSchema: false suppresses ajv's warning about those `default`
+// annotations being present without `useDefaults`. Other strict checks
+// (strict types, strict tuples) stay on — `strict: false` would have
+// disabled them too, which we don't want.
+//
+// The (Ajv2020 as ...).default ?? Ajv2020 dance survives a future ajv ESM
+// migration: today the import is CJS-over-ESM interop and the constructor
+// lives at .default; if ajv ships a real ESM build, .default goes away
+// and the fallback picks up the module export directly.
+const AjvCtor =
+	(Ajv2020 as unknown as { default?: typeof Ajv2020.default }).default ??
+	(Ajv2020 as unknown as typeof Ajv2020.default);
+const ajv = new AjvCtor({
+	strictSchema: false,
 	allErrors: true,
 });
 
@@ -201,7 +214,10 @@ export async function loadConfig(configPath: string = DEFAULT_CONFIG_PATH): Prom
 
 	if (!validateConfig(parsed)) {
 		const errs = (validateConfig.errors ?? [])
-			.map((e) => `  ${e.instancePath || "(root)"} ${e.message}${e.params ? ` ${JSON.stringify(e.params)}` : ""}`)
+			.map(
+				(e: { instancePath?: string; message?: string; params?: unknown }) =>
+					`  ${e.instancePath || "(root)"} ${e.message}${e.params ? ` ${JSON.stringify(e.params)}` : ""}`,
+			)
 			.join("\n");
 		throw new ConfigError(
 			`Schema validation failed for ${configPath}:\n${errs}`,

--- a/src/host.ts
+++ b/src/host.ts
@@ -13,7 +13,17 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-import type { ServerConfig } from "./index.js";
+/**
+ * Narrow shape the host needs to spawn an MCP child. The richer config
+ * (trust, endpointMode, direct/adapter discriminator) lives in src/config.ts;
+ * the entrypoint resolves it down to this before spawning.
+ */
+export interface HostSpawnConfig {
+	name: string;
+	command: string;
+	args?: string[];
+	env?: Record<string, string>;
+}
 
 export type CrudeVerb = "create" | "read" | "update" | "delete" | "execute";
 
@@ -41,7 +51,7 @@ const TOOL_FOR_VERB: Record<CrudeVerb, string> = {
 	execute: "mcp_aql_execute",
 };
 
-export async function spawnHost(config: ServerConfig): Promise<MCPHost> {
+export async function spawnHost(config: HostSpawnConfig): Promise<MCPHost> {
 	const env = config.env ? { ...filteredProcessEnv(), ...config.env } : undefined;
 
 	const transport = new StdioClientTransport({

--- a/src/host.ts
+++ b/src/host.ts
@@ -102,14 +102,19 @@ export function parseCrudeResponse(result: unknown): CrudeResponse {
 	};
 
 	if (r.structuredContent && typeof r.structuredContent === "object") {
-		return r.structuredContent as CrudeResponse;
+		const validated = validateCrudeResponse(r.structuredContent);
+		if (validated) return validated;
+		// structuredContent was present but didn't match the discriminated shape;
+		// fall through to other paths so a parseable text frame can still win.
 	}
 
 	if (Array.isArray(r.content)) {
 		const first = r.content[0] as { type?: string; text?: string } | undefined;
 		if (first?.type === "text" && typeof first.text === "string") {
 			try {
-				return JSON.parse(first.text) as CrudeResponse;
+				const parsed = JSON.parse(first.text) as unknown;
+				const validated = validateCrudeResponse(parsed);
+				if (validated) return validated;
 			} catch {
 				// Fall through to malformed.
 			}
@@ -127,6 +132,30 @@ export function parseCrudeResponse(result: unknown): CrudeResponse {
 	}
 
 	return malformed("Could not parse MCP-AQL response from upstream");
+}
+
+/**
+ * Minimal runtime shape check for the MCP-AQL discriminated response.
+ * Returns the value typed as CrudeResponse if it conforms, else undefined.
+ * This is the boundary between user-supplied / third-party servers and
+ * the rest of the bridge — typecasts alone aren't enough.
+ */
+function validateCrudeResponse(value: unknown): CrudeResponse | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const v = value as { success?: unknown; data?: unknown; error?: unknown };
+	if (v.success === true && "data" in v) {
+		return { success: true, data: v.data };
+	}
+	if (v.success === false && v.error && typeof v.error === "object") {
+		const e = v.error as { code?: unknown; message?: unknown; details?: unknown };
+		if (typeof e.code === "string" && typeof e.message === "string") {
+			return {
+				success: false,
+				error: { code: e.code, message: e.message, details: e.details },
+			};
+		}
+	}
+	return undefined;
 }
 
 function malformed(message: string): CrudeResponse {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,64 +1,57 @@
 /**
  * @mcpaql/pi-bridge — Pi extension entrypoint.
  *
- * Hosts MCP-AQL adapters configured by the user and exposes their CRUDE
- * operations as per-server Pi tools (`<server>_create`, `<server>_read`, …).
- *
- * Walking-skeleton scope: hardcoded inline config (real schema/parser is #3),
- * MCP child host stubbed (lands in #4), CRUDE registration stubbed (lands in #5).
- * Pi awaits async factories before `session_start`, so all tool registrations
- * land before the LLM sees the tool list.
+ * Hosts MCP-AQL adapters configured in ~/.pi/mcpaql.config.json and exposes
+ * their CRUDE operations as per-server Pi tools (`<server>_create`,
+ * `<server>_read`, …). Pi awaits async factories before session_start, so
+ * config load + child spawn + tool registration all complete before the LLM
+ * sees the tool list.
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+import { ConfigError, loadConfig, type ResolvedServerConfig } from "./config.js";
 import { type MCPHost, spawnHost } from "./host.js";
 import { registerCrudeTools } from "./register.js";
 
-export type TrustLevel = "untrusted" | "user" | "developer" | "admin";
-
-export type EndpointMode = "multi" | "unified";
-
-export interface ServerConfig {
-	name: string;
-	transport: "stdio";
-	command: string;
-	args?: string[];
-	env?: Record<string, string>;
-	direct?: boolean;
-	trust: TrustLevel;
-	endpointMode?: EndpointMode;
-}
-
-const HARDCODED_SERVERS: ServerConfig[] = [
-	{
-		name: "github",
-		transport: "stdio",
-		command: "node",
-		args: [
-			"/Users/mick/Developer/Organizations/MCPAQL/examples/generated/github-mcp/adapter/dist/server.js",
-		],
-		env: {
-			GITHUB_PERSONAL_ACCESS_TOKEN:
-				process.env.GITHUB_PERSONAL_ACCESS_TOKEN ?? process.env.GITHUB_TOKEN ?? "",
-		},
-		trust: "user",
-		endpointMode: "multi",
-	},
-];
+// Re-exports so consumers using the package programmatically don't need
+// to reach into subpaths.
+export {
+	type EndpointMode,
+	type LoadResult,
+	type ResolvedAdapterConfig,
+	type ResolvedDirectConfig,
+	type ResolvedServerConfig,
+	type TrustLevel,
+	ConfigError,
+	loadConfig,
+	MCPAQL_CONFIG_SCHEMA,
+} from "./config.js";
 
 const piBridge = async function (pi: ExtensionAPI): Promise<void> {
 	const hosts: MCPHost[] = [];
-	const failures: Array<{ name: string; reason: string }> = [];
+	const failures: string[] = [];
+	const notices: string[] = [];
 
-	for (const server of HARDCODED_SERVERS) {
+	let configResult: Awaited<ReturnType<typeof loadConfig>> | null = null;
+	try {
+		configResult = await loadConfig();
+		notices.push(...configResult.notices);
+	} catch (err) {
+		if (err instanceof ConfigError) {
+			failures.push(err.message);
+		} else {
+			failures.push(`Config load failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	for (const server of configResult?.servers ?? []) {
 		try {
-			hosts.push(await spawnHost(server));
+			hosts.push(await spawnAndRegister(pi, server));
 		} catch (err) {
-			failures.push({
-				name: server.name,
-				reason: err instanceof Error ? err.message : String(err),
-			});
+			failures.push(
+				`Server "${server.name}": ${err instanceof Error ? err.message : String(err)}`,
+			);
 		}
 	}
 
@@ -68,21 +61,42 @@ const piBridge = async function (pi: ExtensionAPI): Promise<void> {
 				`@mcpaql/pi-bridge loaded — ${hosts.length} server(s): ${hosts.map((h) => h.serverName).join(", ")}`,
 				"info",
 			);
+		} else if (configResult?.loaded) {
+			ctx.ui.notify("@mcpaql/pi-bridge: config loaded but no servers spawned.", "warning");
 		} else {
-			ctx.ui.notify("@mcpaql/pi-bridge loaded (no servers configured)", "info");
+			ctx.ui.notify("@mcpaql/pi-bridge loaded (no config file).", "info");
+		}
+		for (const note of notices) {
+			ctx.ui.notify(note, "info");
 		}
 		for (const f of failures) {
-			ctx.ui.notify(`@mcpaql/pi-bridge: failed to spawn ${f.name} — ${f.reason}`, "warning");
+			ctx.ui.notify(`@mcpaql/pi-bridge: ${f}`, "warning");
 		}
 	});
-
-	for (const host of hosts) {
-		registerCrudeTools(pi, host);
-	}
 
 	pi.on("session_shutdown", async () => {
 		await Promise.allSettled(hosts.map((h) => h.close()));
 	});
 };
+
+async function spawnAndRegister(
+	pi: ExtensionAPI,
+	server: ResolvedServerConfig,
+): Promise<MCPHost> {
+	if (server.kind === "adapter") {
+		throw new Error(
+			`adapter "${server.adapter}" — package resolution lands in #6; use direct: true with command/args for now.`,
+		);
+	}
+
+	const host = await spawnHost({
+		name: server.name,
+		command: server.command,
+		args: server.args,
+		env: server.env,
+	});
+	registerCrudeTools(pi, host);
+	return host;
+}
 
 export default piBridge;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,15 @@ const piBridge = async function (pi: ExtensionAPI): Promise<void> {
 	}
 
 	for (const server of configResult?.servers ?? []) {
+		// Adapter resolution (#6) is not yet implemented. Surface this as an
+		// info-level notice rather than a warning, so users distinguish
+		// "feature isn't built yet" from "spawn actually failed".
+		if (server.kind === "adapter") {
+			notices.push(
+				`Server "${server.name}": kind="adapter" is not yet implemented — waiting on #6 (adapter package resolution). Skipping; use kind="direct" with command/args for now.`,
+			);
+			continue;
+		}
 		try {
 			hosts.push(await spawnAndRegister(pi, server));
 		} catch (err) {
@@ -84,8 +93,11 @@ async function spawnAndRegister(
 	server: ResolvedServerConfig,
 ): Promise<MCPHost> {
 	if (server.kind === "adapter") {
+		// Defense in depth — the loop above filters these out and surfaces a
+		// notice, but if a future code path reaches here, fail loud rather
+		// than spawn nothing.
 		throw new Error(
-			`adapter "${server.adapter}" — package resolution lands in #6; use direct: true with command/args for now.`,
+			`internal: kind="adapter" reached spawnAndRegister; the entrypoint should have filtered "${server.name}" out (waiting on #6).`,
 		);
 	}
 

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -1,0 +1,214 @@
+/**
+ * Tests for the config loader: missing files, malformed JSON, schema
+ * validation, env interpolation, defaults, duplicate names.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { ConfigError, loadConfig } from "../dist/config.js";
+
+let workdir;
+let cfgPath;
+
+beforeEach(async () => {
+	workdir = await mkdtemp(join(tmpdir(), "mcpaql-cfg-"));
+	cfgPath = join(workdir, "mcpaql.config.json");
+});
+
+afterEach(async () => {
+	await rm(workdir, { recursive: true, force: true });
+});
+
+async function writeCfg(obj) {
+	await writeFile(cfgPath, JSON.stringify(obj, null, 2));
+}
+
+test("missing config file → empty servers + soft notice, no error", async () => {
+	const r = await loadConfig(join(workdir, "does-not-exist.json"));
+	assert.equal(r.loaded, false);
+	assert.deepEqual(r.servers, []);
+	assert.equal(r.notices.length, 1);
+	assert.match(r.notices[0], /No config file at/);
+});
+
+test("malformed JSON throws ConfigError with file path", async () => {
+	await writeFile(cfgPath, "{ this is not json");
+	await assert.rejects(
+		loadConfig(cfgPath),
+		(err) => err instanceof ConfigError && err.configPath === cfgPath && /Malformed JSON/.test(err.message),
+	);
+});
+
+test("missing required field → ConfigError mentions the field", async () => {
+	await writeCfg({ servers: [{ name: "foo", direct: true }] }); // missing command
+	await assert.rejects(loadConfig(cfgPath), (err) => err instanceof ConfigError && /must match exactly one schema in oneOf|command/.test(err.message));
+});
+
+test("server with neither direct nor adapter → ConfigError (oneOf)", async () => {
+	await writeCfg({ servers: [{ name: "foo", command: "x" }] });
+	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});
+
+test("server with both direct and adapter → ConfigError", async () => {
+	await writeCfg({ servers: [{ name: "foo", direct: true, command: "x", adapter: "y" }] });
+	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});
+
+test("invalid name (uppercase) → ConfigError", async () => {
+	await writeCfg({ servers: [{ name: "Foo", direct: true, command: "x" }] });
+	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});
+
+test("duplicate server names → ConfigError listing the duplicate", async () => {
+	await writeCfg({
+		servers: [
+			{ name: "dup", direct: true, command: "a" },
+			{ name: "dup", direct: true, command: "b" },
+		],
+	});
+	await assert.rejects(
+		loadConfig(cfgPath),
+		(err) => err instanceof ConfigError && /Duplicate server name "dup"/.test(err.message),
+	);
+});
+
+test("valid direct config → kind=direct with defaults applied", async () => {
+	await writeCfg({
+		servers: [
+			{
+				name: "dollhouse",
+				direct: true,
+				command: "npx",
+				args: ["@dollhousemcp/mcp-server"],
+			},
+		],
+	});
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.loaded, true);
+	assert.equal(r.servers.length, 1);
+	const s = r.servers[0];
+	assert.equal(s.kind, "direct");
+	assert.equal(s.name, "dollhouse");
+	assert.equal(s.command, "npx");
+	assert.deepEqual(s.args, ["@dollhousemcp/mcp-server"]);
+	assert.equal(s.transport, "stdio");
+	assert.equal(s.trust, "user");
+	assert.equal(s.endpointMode, "multi");
+	assert.deepEqual(s.env, {});
+});
+
+test("valid adapter config → kind=adapter with defaults applied", async () => {
+	await writeCfg({
+		servers: [
+			{
+				name: "github",
+				adapter: "@mcpaql/generated-github-mcp",
+			},
+		],
+	});
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.servers[0].kind, "adapter");
+	assert.equal(r.servers[0].adapter, "@mcpaql/generated-github-mcp");
+	assert.equal(r.servers[0].trust, "user");
+	assert.equal(r.servers[0].endpointMode, "multi");
+});
+
+test("explicit trust / endpointMode override defaults", async () => {
+	await writeCfg({
+		servers: [
+			{
+				name: "dollhouse",
+				direct: true,
+				command: "x",
+				trust: "developer",
+				endpointMode: "unified",
+			},
+		],
+	});
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.servers[0].trust, "developer");
+	assert.equal(r.servers[0].endpointMode, "unified");
+});
+
+test("${env:VAR} interpolation expands when var is set", async () => {
+	const original = process.env.MCPAQL_TEST_TOKEN;
+	process.env.MCPAQL_TEST_TOKEN = "secret-value";
+	try {
+		await writeCfg({
+			servers: [
+				{
+					name: "github",
+					adapter: "x",
+					env: { TOKEN: "${env:MCPAQL_TEST_TOKEN}" },
+				},
+			],
+		});
+		const r = await loadConfig(cfgPath);
+		assert.equal(r.servers[0].env.TOKEN, "secret-value");
+		assert.equal(r.notices.length, 0);
+	} finally {
+		if (original === undefined) delete process.env.MCPAQL_TEST_TOKEN;
+		else process.env.MCPAQL_TEST_TOKEN = original;
+	}
+});
+
+test("${env:VAR} interpolation falls back to empty + notice when unset", async () => {
+	delete process.env.MCPAQL_DEFINITELY_NOT_SET;
+	await writeCfg({
+		servers: [
+			{
+				name: "github",
+				adapter: "x",
+				env: { TOKEN: "${env:MCPAQL_DEFINITELY_NOT_SET}" },
+			},
+		],
+	});
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.servers[0].env.TOKEN, "");
+	assert.equal(r.notices.length, 1);
+	assert.match(r.notices[0], /MCPAQL_DEFINITELY_NOT_SET is unset/);
+});
+
+test("multiple ${env:VAR} substitutions in one value", async () => {
+	process.env.MCPAQL_TEST_A = "alpha";
+	process.env.MCPAQL_TEST_B = "beta";
+	try {
+		await writeCfg({
+			servers: [
+				{
+					name: "x",
+					adapter: "y",
+					env: { COMBO: "${env:MCPAQL_TEST_A}-${env:MCPAQL_TEST_B}" },
+				},
+			],
+		});
+		const r = await loadConfig(cfgPath);
+		assert.equal(r.servers[0].env.COMBO, "alpha-beta");
+	} finally {
+		delete process.env.MCPAQL_TEST_A;
+		delete process.env.MCPAQL_TEST_B;
+	}
+});
+
+test("empty servers array is allowed", async () => {
+	await writeCfg({ servers: [] });
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.loaded, true);
+	assert.deepEqual(r.servers, []);
+});
+
+test("unknown top-level field is rejected (additionalProperties: false)", async () => {
+	await writeCfg({ servers: [], extras: {} });
+	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});
+
+test("unknown server field is rejected (additionalProperties: false)", async () => {
+	await writeCfg({
+		servers: [{ name: "foo", direct: true, command: "x", bogus: 1 }],
+	});
+	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});


### PR DESCRIPTION
## Summary
- Replaces `HARDCODED_SERVERS` in the entrypoint with `loadConfig()` reading `~/.pi/mcpaql.config.json`
- Inline JSON Schema (Draft 2020-12) validated via ajv, with discriminated `direct` vs `adapter` server shapes
- `${env:VAR}` interpolation in env values; defaults for `trust`/`endpointMode`/`transport`; `ConfigError` carries the configPath
- Refactors `host.ts` to take a narrow `HostSpawnConfig` ({name, command, args?, env?}) — trust/endpointMode/direct now live with config, not host
- Adapter-kind servers fail fast with "lands in #6"; direct servers spawn and register tools as before

## Test plan
- [x] 38/38 tests passing locally (`npm test`)
- [x] Walking-skeleton smoke harness still works (`node scripts/smoke-host.mjs`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Build clean (`npm run build`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)