### PR TITLE
chore: propagate Claude Code Actions to main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,32 +36,51 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools Bash Read Grep Glob'
           prompt: |
             You are reviewing pull request #${{ github.event.pull_request.number }}
-            on ${{ github.repository }}. Use `gh pr view` and `gh pr diff` (or
-            equivalent tools available to you) to read the PR.
+            on ${{ github.repository }}.
 
-            Always post one top-level review comment on the PR. The comment
-            must contain, in this order:
+            HARD REQUIREMENT: you MUST post exactly one top-level review comment
+            on this PR before exiting. This is non-negotiable. Exiting without
+            posting a top-level comment is a failure of the review, regardless
+            of how trivial the PR is or how few concerns you have.
 
-            **Summary** — 1–2 sentences describing what the PR changes.
+            STEP 1 — Read the PR. Run:
+              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+              gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+            Read related source files as needed.
 
-            **Assessment** — one sentence: approve / request changes / comment,
-            with a one-line reason. If the PR is trivial or clearly correct,
-            say so explicitly; do not stay silent.
+            STEP 2 (mandatory, never skip) — Post the top-level review with:
+              gh pr review ${{ github.event.pull_request.number }} \
+                --repo ${{ github.repository }} \
+                --comment \
+                --body-file <path-to-review-file>
 
-            **Notes** — up to 5 bullets calling out anything a human reviewer
-            should look at: subtle correctness, security, test coverage gaps,
-            mismatch between PR description and actual diff, drift from the
-            project's existing patterns. If you have nothing to flag, write
-            "Nothing flagged."
+            Write the review body to a temporary file first (heredoc to a path
+            under /tmp), then pass it via --body-file. The body must contain
+            these three sections in this exact order:
 
-            You MAY additionally leave inline review comments on specific
-            lines — but only for actionable concerns. Do not leave inline
-            comments for nitpicks or style preferences. Inline comments are
-            in addition to the top-level summary, never instead of it.
+              **Summary** — 1–2 sentences describing what the PR changes.
 
-            Posting the top-level summary is mandatory even if you have no
-            inline comments. A green check with no visible review is hard to
-            interpret at a glance.
+              **Assessment** — one sentence: approve / request changes / comment,
+              with a one-line reason.
+
+              **Notes** — up to 5 bullets calling out anything a human reviewer
+              should look at. If nothing substantive, write "Nothing flagged."
+
+            If the PR is trivial or you have nothing meaningful to say, post
+            the minimum viable review — a one-line summary, "Comment — looks
+            fine.", and "Nothing flagged." Posting a near-empty review is
+            REQUIRED; posting nothing is FORBIDDEN.
+
+            STEP 3 — Verify the comment landed by running:
+              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json reviews
+            The output must show your review. If it does not, retry STEP 2.
+
+            STEP 4 (optional) — You MAY additionally leave inline review
+            comments on specific lines for actionable concerns. Inline comments
+            never replace the top-level review from STEP 2.
+
+            Do not exit until STEP 2 has demonstrably posted a review.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,24 +21,47 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            on ${{ github.repository }}. Use `gh pr view` and `gh pr diff` (or
+            equivalent tools available to you) to read the PR.
+
+            Always post one top-level review comment on the PR. The comment
+            must contain, in this order:
+
+            **Summary** — 1–2 sentences describing what the PR changes.
+
+            **Assessment** — one sentence: approve / request changes / comment,
+            with a one-line reason. If the PR is trivial or clearly correct,
+            say so explicitly; do not stay silent.
+
+            **Notes** — up to 5 bullets calling out anything a human reviewer
+            should look at: subtle correctness, security, test coverage gaps,
+            mismatch between PR description and actual diff, drift from the
+            project's existing patterns. If you have nothing to flag, write
+            "Nothing flagged."
+
+            You MAY additionally leave inline review comments on specific
+            lines — but only for actionable concerns. Do not leave inline
+            comments for nitpicks or style preferences. Inline comments are
+            in addition to the top-level summary, never instead of it.
+
+            Posting the top-level summary is mandatory even if you have no
+            inline comments. A green check with no visible review is hard to
+            interpret at a glance.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+


### PR DESCRIPTION
## Summary
Propagates the Claude Code Actions setup (PR #27) from `develop` to `main` so the `claude-review` workflow also triggers on `develop → main` release PRs going forward.

This is the first develop → main sync — also exercises the branch-protection rule on `main` (PR required, no direct pushes).

## Test plan
- [ ] CI green
- [ ] After merge, opening a future `develop → main` release PR triggers `claude-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)