### PR TITLE
Make Claude review prompt always post a visible top-level comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,24 +21,47 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            on ${{ github.repository }}. Use `gh pr view` and `gh pr diff` (or
+            equivalent tools available to you) to read the PR.
+
+            Always post one top-level review comment on the PR. The comment
+            must contain, in this order:
+
+            **Summary** — 1–2 sentences describing what the PR changes.
+
+            **Assessment** — one sentence: approve / request changes / comment,
+            with a one-line reason. If the PR is trivial or clearly correct,
+            say so explicitly; do not stay silent.
+
+            **Notes** — up to 5 bullets calling out anything a human reviewer
+            should look at: subtle correctness, security, test coverage gaps,
+            mismatch between PR description and actual diff, drift from the
+            project's existing patterns. If you have nothing to flag, write
+            "Nothing flagged."
+
+            You MAY additionally leave inline review comments on specific
+            lines — but only for actionable concerns. Do not leave inline
+            comments for nitpicks or style preferences. Inline comments are
+            in addition to the top-level summary, never instead of it.
+
+            Posting the top-level summary is mandatory even if you have no
+            inline comments. A green check with no visible review is hard to
+            interpret at a glance.
 


### PR DESCRIPTION
## Summary
The plugin-based review (`/code-review:code-review`) silently no-ops when there's nothing to flag inline — PR #28 hit that path. Replacing the prompt with an explicit one that always posts a top-level review comment containing **Summary / Assessment / Notes**, plus optional inline comments for actionable concerns.

Bumped permissions from `read` to `write` on pull-requests/issues so the action can actually post the comment. `fetch-depth: 0` so Claude can diff against the base branch if it wants.

## Test plan
- [x] CI green (typecheck + build)
- [ ] **claude-review posts a visible top-level comment on this PR** — meta-test of the new prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)