### PR TITLE
Adapter package resolution: local paths + npm packages (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ Configured via `~/.pi/mcpaql.config.json`:
 
 | Spec | Resolves to | Example |
 |---|---|---|
-| **Local path** (absolute, `./relative`, `../relative`, `~/home`, bare `~`, Windows drive) | `node <path>/dist/server.js` — convention is the entry lives at `dist/server.js` inside the directory | `/Users/me/adapters/github` |
+| **Local path** (absolute, `./relative`, `../relative`, bare `..`, `~/home`, bare `~`) | `node <path>/dist/server.js` — convention is the entry lives at `dist/server.js` inside the directory | `/Users/me/adapters/github` |
 | **npm package** (bare name, scoped, version-pinned) | `npx --yes <name>` — npx handles fetch + cache automatically | `@mcpaql/generated-github-mcp@1.2.3` |
 | **git URL** (`git:host/owner/repo@ref` or `git+https://…`) | *Not yet implemented — tracked in issue #31* | `git:github.com/user/repo@v1` |
 
 Specs containing `/` that aren't the npm scoped form (`@scope/name`) are rejected with explicit guidance — `adapters/my-server` is treated as ambiguous and prompts you to use either `./adapters/my-server` (local) or `@scope/name` (npm).
 
+For local paths, the entry file at `<path>/dist/server.js` is checked for existence at startup, so a wrong path or missing build surfaces immediately with an actionable error rather than at first tool call. Permission-denied and missing-file cases produce distinct messages.
+
 The `dist/server.js` entry-point is convention; per-adapter entry overrides (or `package.json#bin` lookup) are tracked as a follow-up.
+
+> **Platform note.** Windows drive-letter paths (e.g. `C:\path\to\adapter`) are recognized as a local-path shape so Windows users get a sensible error message rather than silent dispatch to npx, but the supported runtime for this package is Node 20+ on Linux/macOS. Windows is not on the release matrix.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,22 @@ Configured via `~/.pi/mcpaql.config.json`:
 }
 ```
 
-- `direct: true` — server already speaks MCP-AQL natively; talk straight to its `mcp_aql_*` tools.
-- `adapter: "<package>"` — wrap a non-MCP-AQL server with a generated adapter, then expose that.
+- `direct: true` — server already speaks MCP-AQL natively; talk straight to its `mcp_aql_*` tools. Requires `command` and `args`.
+- `adapter: "<spec>"` — wrap a non-MCP-AQL server with a generated adapter, then expose that. The spec recognizes three forms (see *Adapter spec forms* below).
 - `endpointMode: "multi" | "unified"` — 5 separate Pi tools per server, or 1 unified tool with the operation name in params.
 - `trust` — gatekeeper trust level for this server (`untrusted` / `user` / `developer` / `admin`).
+
+### Adapter spec forms
+
+| Spec | Resolves to | Example |
+|---|---|---|
+| **Local path** (absolute, `./relative`, `../relative`, `~/home`, bare `~`, Windows drive) | `node <path>/dist/server.js` — convention is the entry lives at `dist/server.js` inside the directory | `/Users/me/adapters/github` |
+| **npm package** (bare name, scoped, version-pinned) | `npx --yes <name>` — npx handles fetch + cache automatically | `@mcpaql/generated-github-mcp@1.2.3` |
+| **git URL** (`git:host/owner/repo@ref` or `git+https://…`) | *Not yet implemented — tracked in issue #31* | `git:github.com/user/repo@v1` |
+
+Specs containing `/` that aren't the npm scoped form (`@scope/name`) are rejected with explicit guidance — `adapters/my-server` is treated as ambiguous and prompts you to use either `./adapters/my-server` (local) or `@scope/name` (npm).
+
+The `dist/server.js` entry-point is convention; per-adapter entry overrides (or `package.json#bin` lookup) are tracked as a follow-up.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Configured via `~/.pi/mcpaql.config.json`:
 
 | Spec | Resolves to | Example |
 |---|---|---|
-| **Local path** (absolute, `./relative`, `../relative`, bare `..`, `~/home`, bare `~`) | `node <path>/dist/server.js` — convention is the entry lives at `dist/server.js` inside the directory | `/Users/me/adapters/github` |
+| **Local path** (absolute, `./relative`, `../relative`, bare `.`, bare `..`, `~/home`, bare `~`) | `node <path>/dist/server.js` — convention is the entry lives at `dist/server.js` inside the directory | `/Users/me/adapters/github` |
 | **npm package** (bare name, scoped, version-pinned) | `npx --yes <name>` — npx handles fetch + cache automatically | `@mcpaql/generated-github-mcp@1.2.3` |
 | **git URL** (`git:host/owner/repo@ref` or `git+https://…`) | *Not yet implemented — tracked in issue #31* | `git:github.com/user/repo@v1` |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ import { join } from "node:path";
 
 import Ajv2020 from "ajv/dist/2020.js";
 
+import { isNodeError } from "./util.js";
+
 export type TrustLevel = "untrusted" | "user" | "developer" | "admin";
 export type EndpointMode = "multi" | "unified";
 
@@ -308,6 +310,3 @@ function expandEnvMap(
 	return out;
 }
 
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-	return err instanceof Error && "code" in err;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { ConfigError, loadConfig, type ResolvedServerConfig } from "./config.js";
 import { type MCPHost, spawnHost } from "./host.js";
 import { registerCrudeTools } from "./register.js";
+import { resolveAdapter } from "./resolve.js";
 
 // Re-exports so consumers using the package programmatically don't need
 // to reach into subpaths.
@@ -46,15 +47,6 @@ const piBridge = async function (pi: ExtensionAPI): Promise<void> {
 	}
 
 	for (const server of configResult?.servers ?? []) {
-		// Adapter resolution (#6) is not yet implemented. Surface this as an
-		// info-level notice rather than a warning, so users distinguish
-		// "feature isn't built yet" from "spawn actually failed".
-		if (server.kind === "adapter") {
-			notices.push(
-				`Server "${server.name}": kind="adapter" is not yet implemented — waiting on #6 (adapter package resolution). Skipping; use kind="direct" with command/args for now.`,
-			);
-			continue;
-		}
 		try {
 			hosts.push(await spawnAndRegister(pi, server));
 		} catch (err) {
@@ -92,19 +84,15 @@ async function spawnAndRegister(
 	pi: ExtensionAPI,
 	server: ResolvedServerConfig,
 ): Promise<MCPHost> {
-	if (server.kind === "adapter") {
-		// Defense in depth — the loop above filters these out and surfaces a
-		// notice, but if a future code path reaches here, fail loud rather
-		// than spawn nothing.
-		throw new Error(
-			`internal: kind="adapter" reached spawnAndRegister; the entrypoint should have filtered "${server.name}" out (waiting on #6).`,
-		);
-	}
+	const spawnSpec =
+		server.kind === "direct"
+			? { command: server.command, args: server.args }
+			: await resolveAdapter(server);
 
 	const host = await spawnHost({
 		name: server.name,
-		command: server.command,
-		args: server.args,
+		command: spawnSpec.command,
+		args: spawnSpec.args,
 		env: server.env,
 	});
 	registerCrudeTools(pi, host);

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,80 @@
+/**
+ * Adapter package resolution: turns a `kind: "adapter"` config's
+ * `adapter: "<spec>"` string into the {command, args} the host needs to
+ * spawn it.
+ *
+ * Three input shapes are recognized:
+ *
+ *   - **Local path** — absolute, ./relative, ~/home, or path-with-slash.
+ *     Convention: <path>/dist/server.js is the entry. Spawned with `node`.
+ *
+ *   - **npm package** — bare name like `@mcpaql/foo` or `pkg`. Spawned via
+ *     `npx --yes <name>`; npx handles fetch + cache automatically.
+ *
+ *   - **git URL** — `git:host/owner/repo@ref` (Pi-mono convention). Not
+ *     yet implemented; throws a clear error pointing at the tracking
+ *     issue. The clone+install+cache work lands in a follow-up.
+ *
+ * Errors are thrown so the entrypoint can route them through the same
+ * failures[] path as spawn failures, surfacing via ctx.ui.notify.
+ */
+
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
+
+import type { ResolvedAdapterConfig } from "./config.js";
+
+export interface ResolvedSpawn {
+	command: string;
+	args: string[];
+}
+
+export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<ResolvedSpawn> {
+	const spec = server.adapter;
+
+	if (spec.startsWith("git:") || spec.startsWith("git+")) {
+		throw new Error(
+			`adapter "${spec}": git: URLs are not yet implemented. Use a local path or an npm package name for now (tracked separately as a follow-up to #6).`,
+		);
+	}
+
+	if (isLocalPath(spec)) {
+		return resolveLocalPath(spec);
+	}
+
+	// Anything else: treat as an npm package name. npx handles cache + install.
+	return { command: "npx", args: ["--yes", spec] };
+}
+
+function isLocalPath(spec: string): boolean {
+	if (isAbsolute(spec)) return true;
+	if (spec.startsWith("./") || spec.startsWith("../")) return true;
+	if (spec.startsWith("~/") || spec === "~") return true;
+	// Accept Windows-style absolute paths if someone hands us one (defensive;
+	// our supported runtimes are Node 20+ on Linux/macOS, but easy to allow).
+	if (/^[A-Za-z]:[\\/]/.test(spec)) return true;
+	return false;
+}
+
+async function resolveLocalPath(spec: string): Promise<ResolvedSpawn> {
+	const expanded = expandHome(spec);
+	const absolute = isAbsolute(expanded) ? expanded : resolvePath(expanded);
+	const entry = join(absolute, "dist", "server.js");
+
+	try {
+		await access(entry);
+	} catch {
+		throw new Error(
+			`adapter local path "${spec}" — expected ${entry} (build the adapter first, or point adapter at a directory containing dist/server.js).`,
+		);
+	}
+
+	return { command: "node", args: [entry] };
+}
+
+function expandHome(spec: string): string {
+	if (spec === "~") return homedir();
+	if (spec.startsWith("~/")) return join(homedir(), spec.slice(2));
+	return spec;
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -42,6 +42,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 
 import type { ResolvedAdapterConfig } from "./config.js";
+import { isNodeError } from "./util.js";
 
 export interface ResolvedSpawn {
 	command: string;
@@ -80,11 +81,13 @@ export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<Res
 
 function isLocalPath(spec: string): boolean {
 	if (isAbsolute(spec)) return true;
-	if (spec.startsWith("./") || spec.startsWith("../")) return true;
+	if (spec.startsWith("./") || spec === ".." || spec.startsWith("../")) return true;
 	if (spec.startsWith("~/") || spec === "~") return true;
-	// Windows drive-letter absolute paths — `C:\foo`, `D:/bar`. Defensive;
-	// our supported runtime is Node 20+ on Linux/macOS, but the cost of
-	// recognizing the shape is one regex test.
+	// Windows drive-letter absolute paths — `C:\foo`, `D:/bar`. Recognized
+	// defensively so a Windows user pasting a drive path gets a sensible
+	// error instead of having it silently dispatched to npx. Note that the
+	// supported runtime is Node 20+ on Linux/macOS; Windows is not on the
+	// release matrix, so this is footprint, not full support.
 	if (/^[A-Za-z]:[\\/]/.test(spec)) return true;
 	return false;
 }
@@ -94,19 +97,27 @@ async function resolveLocalPath(spec: string): Promise<ResolvedSpawn> {
 	const absolute = isAbsolute(expanded) ? expanded : resolvePath(expanded);
 	const entry = join(absolute, DEFAULT_ENTRY_RELATIVE);
 
+	// Probe the entry up front so config errors surface at startup rather
+	// than at first tool call. We narrow on the error code so each failure
+	// mode gets actionable feedback:
+	//   ENOENT → "build the adapter first / wrong path"
+	//   EACCES → "permission denied / check perms"
+	//   anything else (EMFILE, EIO, …) → propagate verbatim, since giving
+	//     it our generic message would actively mislead the user.
 	try {
 		await access(entry);
 	} catch (err) {
-		// Distinguish "doesn't exist" from "permission denied" so the user
-		// gets actionable feedback rather than a generic "expected …" error.
 		if (isNodeError(err) && err.code === "EACCES") {
 			throw new Error(
 				`adapter local path "${spec}": permission denied reading ${entry} — check filesystem permissions on the adapter directory.`,
 			);
 		}
-		throw new Error(
-			`adapter local path "${spec}" — expected ${entry} (build the adapter first, or point adapter at a directory containing dist/server.js).`,
-		);
+		if (isNodeError(err) && err.code === "ENOENT") {
+			throw new Error(
+				`adapter local path "${spec}": expected ${entry} (build the adapter first, or point adapter at a directory containing ${DEFAULT_ENTRY_RELATIVE}).`,
+			);
+		}
+		throw err;
 	}
 
 	return { command: "node", args: [entry] };
@@ -116,8 +127,4 @@ function expandHome(spec: string): string {
 	if (spec === "~") return homedir();
 	if (spec.startsWith("~/")) return join(homedir(), spec.slice(2));
 	return spec;
-}
-
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-	return err instanceof Error && "code" in err;
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -43,6 +43,16 @@ export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<Res
 		return resolveLocalPath(spec);
 	}
 
+	// Reject ambiguous specs that look like paths but aren't explicitly
+	// rooted. Without this, "adapters/my-server" would silently resolve to
+	// `npx adapters/my-server`, which is almost never what the user meant.
+	// The only legitimate slash-containing form for npm is @scope/name.
+	if (spec.includes("/") && !/^@[^/]+\/[^/]+$/.test(spec)) {
+		throw new Error(
+			`adapter "${spec}": looks like a path but isn't rooted. Prefix with "./" for a relative path, or use the npm scoped-package form @scope/name.`,
+		);
+	}
+
 	// Anything else: treat as an npm package name. npx handles cache + install.
 	return { command: "npx", args: ["--yes", spec] };
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -3,20 +3,38 @@
  * `adapter: "<spec>"` string into the {command, args} the host needs to
  * spawn it.
  *
- * Three input shapes are recognized:
+ * Three input shapes are recognized, in this strict order:
  *
- *   - **Local path** — absolute, ./relative, ~/home, or path-with-slash.
- *     Convention: <path>/dist/server.js is the entry. Spawned with `node`.
+ *   1. **git URL** — `git:host/owner/repo@ref` or `git+https://…`.
+ *      Currently throws "not yet implemented" — clone/install/cache lands
+ *      in a follow-up. Checked first so a leading `git:` is never mistaken
+ *      for an npm package whose name happens to start with `git`.
  *
- *   - **npm package** — bare name like `@mcpaql/foo` or `pkg`. Spawned via
- *     `npx --yes <name>`; npx handles fetch + cache automatically.
+ *   2. **Local path** — absolute, `./relative`, `../relative`, `~/home`,
+ *      bare `~`, or Windows drive paths. Convention: `<path>/dist/server.js`
+ *      is the entry. Spawned with `node`. Checked second so explicit local
+ *      forms always win over ambiguous interpretation.
  *
- *   - **git URL** — `git:host/owner/repo@ref` (Pi-mono convention). Not
- *     yet implemented; throws a clear error pointing at the tracking
- *     issue. The clone+install+cache work lands in a follow-up.
+ *   3. **npm package** — bare name like `@mcpaql/foo`, `pkg`, or
+ *      version-pinned `pkg@1.2.3` / `@scope/name@1.2.3`. Spawned via
+ *      `npx --yes <name>`; npx handles fetch + cache automatically.
+ *      Specs with embedded slashes that aren't valid scoped-package shape
+ *      are rejected as ambiguous before reaching this branch.
+ *
+ * Trust model: the adapter spec comes from a config file the user owns
+ * (`~/.pi/mcpaql.config.json`), so `npx --yes <whatever-the-user-wrote>`
+ * runs whatever the user typed. This is acceptable because the config is
+ * local and user-controlled. If config ever flows in from a remote source,
+ * this assumption needs revisiting.
  *
  * Errors are thrown so the entrypoint can route them through the same
  * failures[] path as spawn failures, surfacing via ctx.ui.notify.
+ *
+ * Future work tracked separately:
+ *   - git URL support (clone + install + cache)
+ *   - Per-adapter entry override (when `dist/server.js` doesn't fit) —
+ *     candidates: read `package.json` `bin` field, or accept an object
+ *     spec `{ path, entry }`.
  */
 
 import { access } from "node:fs/promises";
@@ -29,6 +47,14 @@ export interface ResolvedSpawn {
 	command: string;
 	args: string[];
 }
+
+const DEFAULT_ENTRY_RELATIVE = join("dist", "server.js");
+
+// npm scoped-package shape: `@scope/name`, no extra slashes. Used to
+// distinguish legitimate scoped names from ambiguous slash-containing
+// strings like `adapters/my-server` that almost always indicate a missing
+// `./` prefix.
+const SCOPED_PACKAGE_RE = /^@[^/]+\/[^/]+$/;
 
 export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<ResolvedSpawn> {
 	const spec = server.adapter;
@@ -43,17 +69,12 @@ export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<Res
 		return resolveLocalPath(spec);
 	}
 
-	// Reject ambiguous specs that look like paths but aren't explicitly
-	// rooted. Without this, "adapters/my-server" would silently resolve to
-	// `npx adapters/my-server`, which is almost never what the user meant.
-	// The only legitimate slash-containing form for npm is @scope/name.
-	if (spec.includes("/") && !/^@[^/]+\/[^/]+$/.test(spec)) {
+	if (spec.includes("/") && !SCOPED_PACKAGE_RE.test(spec)) {
 		throw new Error(
 			`adapter "${spec}": looks like a path but isn't rooted. Prefix with "./" for a relative path, or use the npm scoped-package form @scope/name.`,
 		);
 	}
 
-	// Anything else: treat as an npm package name. npx handles cache + install.
 	return { command: "npx", args: ["--yes", spec] };
 }
 
@@ -61,8 +82,9 @@ function isLocalPath(spec: string): boolean {
 	if (isAbsolute(spec)) return true;
 	if (spec.startsWith("./") || spec.startsWith("../")) return true;
 	if (spec.startsWith("~/") || spec === "~") return true;
-	// Accept Windows-style absolute paths if someone hands us one (defensive;
-	// our supported runtimes are Node 20+ on Linux/macOS, but easy to allow).
+	// Windows drive-letter absolute paths — `C:\foo`, `D:/bar`. Defensive;
+	// our supported runtime is Node 20+ on Linux/macOS, but the cost of
+	// recognizing the shape is one regex test.
 	if (/^[A-Za-z]:[\\/]/.test(spec)) return true;
 	return false;
 }
@@ -70,11 +92,18 @@ function isLocalPath(spec: string): boolean {
 async function resolveLocalPath(spec: string): Promise<ResolvedSpawn> {
 	const expanded = expandHome(spec);
 	const absolute = isAbsolute(expanded) ? expanded : resolvePath(expanded);
-	const entry = join(absolute, "dist", "server.js");
+	const entry = join(absolute, DEFAULT_ENTRY_RELATIVE);
 
 	try {
 		await access(entry);
-	} catch {
+	} catch (err) {
+		// Distinguish "doesn't exist" from "permission denied" so the user
+		// gets actionable feedback rather than a generic "expected …" error.
+		if (isNodeError(err) && err.code === "EACCES") {
+			throw new Error(
+				`adapter local path "${spec}": permission denied reading ${entry} — check filesystem permissions on the adapter directory.`,
+			);
+		}
 		throw new Error(
 			`adapter local path "${spec}" — expected ${entry} (build the adapter first, or point adapter at a directory containing dist/server.js).`,
 		);
@@ -87,4 +116,8 @@ function expandHome(spec: string): string {
 	if (spec === "~") return homedir();
 	if (spec.startsWith("~/")) return join(homedir(), spec.slice(2));
 	return spec;
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+	return err instanceof Error && "code" in err;
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -37,6 +37,7 @@
  *     spec `{ path, entry }`.
  */
 
+import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
@@ -62,7 +63,7 @@ export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<Res
 
 	if (spec.startsWith("git:") || spec.startsWith("git+")) {
 		throw new Error(
-			`adapter "${spec}": git: URLs are not yet implemented. Use a local path or an npm package name for now (tracked separately as a follow-up to #6).`,
+			`adapter "${spec}": git: URLs are not yet implemented (tracked in #31). Use a local path or an npm package name for now.`,
 		);
 	}
 
@@ -81,7 +82,12 @@ export async function resolveAdapter(server: ResolvedAdapterConfig): Promise<Res
 
 function isLocalPath(spec: string): boolean {
 	if (isAbsolute(spec)) return true;
-	if (spec.startsWith("./") || spec === ".." || spec.startsWith("../")) return true;
+	// Bare "." and ".." plus prefixed forms. Without the bare-equality checks,
+	// these would match no other branch and silently fall through to `npx .`
+	// or `npx ..` — valid npm semantics ("run the package in CWD") but almost
+	// never what the user intended in a config file.
+	if (spec === "." || spec.startsWith("./")) return true;
+	if (spec === ".." || spec.startsWith("../")) return true;
 	if (spec.startsWith("~/") || spec === "~") return true;
 	// Windows drive-letter absolute paths — `C:\foo`, `D:/bar`. Recognized
 	// defensively so a Windows user pasting a drive path gets a sensible
@@ -98,14 +104,16 @@ async function resolveLocalPath(spec: string): Promise<ResolvedSpawn> {
 	const entry = join(absolute, DEFAULT_ENTRY_RELATIVE);
 
 	// Probe the entry up front so config errors surface at startup rather
-	// than at first tool call. We narrow on the error code so each failure
-	// mode gets actionable feedback:
+	// than at first tool call. R_OK rather than F_OK so a mode-000 file
+	// produces EACCES (existence + readable), not just F_OK (existence).
+	// We narrow on the error code so each failure mode gets actionable
+	// feedback:
 	//   ENOENT → "build the adapter first / wrong path"
 	//   EACCES → "permission denied / check perms"
 	//   anything else (EMFILE, EIO, …) → propagate verbatim, since giving
 	//     it our generic message would actively mislead the user.
 	try {
-		await access(entry);
+		await access(entry, fsConstants.R_OK);
 	} catch (err) {
 		if (isNodeError(err) && err.code === "EACCES") {
 			throw new Error(

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -10,10 +10,11 @@
  *      in a follow-up. Checked first so a leading `git:` is never mistaken
  *      for an npm package whose name happens to start with `git`.
  *
- *   2. **Local path** — absolute, `./relative`, `../relative`, `~/home`,
- *      bare `~`, or Windows drive paths. Convention: `<path>/dist/server.js`
- *      is the entry. Spawned with `node`. Checked second so explicit local
- *      forms always win over ambiguous interpretation.
+ *   2. **Local path** — absolute, `./relative`, `../relative`, bare `.`,
+ *      bare `..`, `~/home`, bare `~`, or Windows drive paths. Convention:
+ *      `<path>/dist/server.js` is the entry. Spawned with `node`. Checked
+ *      second so explicit local forms always win over ambiguous
+ *      interpretation.
  *
  *   3. **npm package** — bare name like `@mcpaql/foo`, `pkg`, or
  *      version-pinned `pkg@1.2.3` / `@scope/name@1.2.3`. Spawned via

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared internal utilities. Not part of the public API surface.
+ */
+
+/**
+ * Type guard for Node.js filesystem errors. Narrows `unknown` to
+ * `NodeJS.ErrnoException` so callers can branch on `.code`.
+ */
+export function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+	return err instanceof Error && "code" in err;
+}

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -58,6 +58,11 @@ test("absolute path with no dist/server.js → throws with the expected entry pa
 });
 
 test("relative ./path resolves against cwd", async () => {
+	// chdir is a global side effect, but node:test runs tests sequentially
+	// within a file by default, so this is safe as long as the finally block
+	// always restores the original cwd. If the test runner ever moves to
+	// concurrent-within-file execution, this needs a different approach
+	// (e.g., a relative-path helper that takes an explicit base directory).
 	await makeAdapterDir(workdir);
 	const cwd = process.cwd();
 	process.chdir(workdir);
@@ -74,7 +79,17 @@ test("relative ./path resolves against cwd", async () => {
 	}
 });
 
-test("~ expands to homedir", async () => {
+test("bare ~ expands to homedir", async () => {
+	// Resolves "~" by itself (not "~/something") to the home directory,
+	// then tries to find dist/server.js inside it. We don't expect a real
+	// adapter at homedir(), so this asserts on the helpful error message.
+	await assert.rejects(
+		resolveAdapter(adapterConfig("~")),
+		(err) => err instanceof Error && err.message.includes(join(homedir(), "dist", "server.js")),
+	);
+});
+
+test("~/path expands to homedir + path", async () => {
 	// We can't actually create files in homedir, so we just check that the
 	// path expansion produces a homedir-rooted entry — even if it doesn't
 	// exist (the test asserts on the error message, not on success).
@@ -94,6 +109,28 @@ test("plain (unscoped) npm package name → npx --yes <package>", async () => {
 	const r = await resolveAdapter(adapterConfig("some-package"));
 	assert.equal(r.command, "npx");
 	assert.deepEqual(r.args, ["--yes", "some-package"]);
+});
+
+test("ambiguous unrooted path-like spec → throws with explicit guidance", async () => {
+	// "adapters/my-server" looks like a relative path but isn't rooted with
+	// ./, ../, ~/, or /. Without rejection, this would silently resolve to
+	// `npx adapters/my-server`, which is almost never what the user meant.
+	await assert.rejects(
+		resolveAdapter(adapterConfig("adapters/my-server")),
+		(err) =>
+			err instanceof Error &&
+			/looks like a path but isn't rooted/.test(err.message) &&
+			/Prefix with "\.\/"/.test(err.message),
+	);
+});
+
+test("multi-segment scoped-package-shaped spec is also ambiguous", async () => {
+	// @scope/pkg is fine; @scope/pkg/extra is not a valid npm name, so we
+	// shouldn't quietly hand it to npx.
+	await assert.rejects(
+		resolveAdapter(adapterConfig("@scope/pkg/extra")),
+		(err) => err instanceof Error && /looks like a path but isn't rooted/.test(err.message),
+	);
 });
 
 test("git: URL → throws not-yet-implemented with mention of #6", async () => {

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Tests for resolveAdapter: turns an adapter spec string into the
+ * {command, args} the host needs to spawn.
+ */
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { resolveAdapter } from "../dist/resolve.js";
+
+let workdir;
+
+beforeEach(async () => {
+	workdir = await mkdtemp(join(tmpdir(), "mcpaql-resolve-"));
+});
+
+afterEach(async () => {
+	await rm(workdir, { recursive: true, force: true });
+});
+
+function adapterConfig(spec) {
+	return {
+		kind: "adapter",
+		name: "test",
+		transport: "stdio",
+		trust: "user",
+		endpointMode: "multi",
+		adapter: spec,
+		env: {},
+	};
+}
+
+async function makeAdapterDir(root, hasServer = true) {
+	const dir = join(root, "adapter");
+	await mkdir(join(dir, "dist"), { recursive: true });
+	if (hasServer) {
+		await writeFile(join(dir, "dist", "server.js"), "// stub\n");
+	}
+	return dir;
+}
+
+test("absolute path with dist/server.js → node + entry path", async () => {
+	const dir = await makeAdapterDir(workdir);
+	const r = await resolveAdapter(adapterConfig(dir));
+	assert.equal(r.command, "node");
+	assert.deepEqual(r.args, [join(dir, "dist", "server.js")]);
+});
+
+test("absolute path with no dist/server.js → throws with the expected entry path", async () => {
+	const dir = await makeAdapterDir(workdir, false);
+	await assert.rejects(
+		resolveAdapter(adapterConfig(dir)),
+		(err) => err instanceof Error && err.message.includes(join(dir, "dist", "server.js")),
+	);
+});
+
+test("relative ./path resolves against cwd", async () => {
+	await makeAdapterDir(workdir);
+	const cwd = process.cwd();
+	process.chdir(workdir);
+	try {
+		const r = await resolveAdapter(adapterConfig("./adapter"));
+		assert.equal(r.command, "node");
+		// On macOS, mkdtemp returns a /var/folders/... path that path.resolve()
+		// canonicalizes to /private/var/folders/..., so we can't compare exact
+		// strings — assert on the trailing suffix and absolute-ness instead.
+		assert.ok(r.args[0].endsWith(join("adapter", "dist", "server.js")));
+		assert.ok(r.args[0].startsWith("/"));
+	} finally {
+		process.chdir(cwd);
+	}
+});
+
+test("~ expands to homedir", async () => {
+	// We can't actually create files in homedir, so we just check that the
+	// path expansion produces a homedir-rooted entry — even if it doesn't
+	// exist (the test asserts on the error message, not on success).
+	await assert.rejects(
+		resolveAdapter(adapterConfig("~/never-exists-mcpaql-test-path")),
+		(err) => err instanceof Error && err.message.includes(join(homedir(), "never-exists-mcpaql-test-path", "dist", "server.js")),
+	);
+});
+
+test("npm package name → npx --yes <package>", async () => {
+	const r = await resolveAdapter(adapterConfig("@mcpaql/some-package"));
+	assert.equal(r.command, "npx");
+	assert.deepEqual(r.args, ["--yes", "@mcpaql/some-package"]);
+});
+
+test("plain (unscoped) npm package name → npx --yes <package>", async () => {
+	const r = await resolveAdapter(adapterConfig("some-package"));
+	assert.equal(r.command, "npx");
+	assert.deepEqual(r.args, ["--yes", "some-package"]);
+});
+
+test("git: URL → throws not-yet-implemented with mention of #6", async () => {
+	await assert.rejects(
+		resolveAdapter(adapterConfig("git:github.com/user/repo@v1")),
+		(err) =>
+			err instanceof Error &&
+			/git:/.test(err.message) &&
+			/not yet implemented/.test(err.message) &&
+			/#6/.test(err.message),
+	);
+});
+
+test("git+... URL also rejected as not-yet-implemented", async () => {
+	await assert.rejects(
+		resolveAdapter(adapterConfig("git+https://github.com/user/repo.git")),
+		(err) => err instanceof Error && /not yet implemented/.test(err.message),
+	);
+});

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -4,7 +4,7 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import { afterEach, beforeEach, test } from "node:test";
@@ -54,6 +54,46 @@ test("absolute path with no dist/server.js → throws with the expected entry pa
 	await assert.rejects(
 		resolveAdapter(adapterConfig(dir)),
 		(err) => err instanceof Error && err.message.includes(join(dir, "dist", "server.js")),
+	);
+});
+
+test("permission denied on entry → distinguishes EACCES from missing file", async (t) => {
+	// chmod 000 on a file makes access(F_OK) succeed but access(R_OK) fail
+	// on POSIX — node's fs/promises access checks F_OK by default, so to
+	// trigger EACCES we need to drop permissions on the parent directory
+	// instead. CI runners running as root bypass perms entirely; skip there.
+	if (process.getuid && process.getuid() === 0) {
+		t.skip("skipped: running as root, perms bypassed");
+		return;
+	}
+	const dir = await makeAdapterDir(workdir);
+	const distDir = join(dir, "dist");
+	await chmod(distDir, 0o000);
+	try {
+		await assert.rejects(
+			resolveAdapter(adapterConfig(dir)),
+			(err) =>
+				err instanceof Error &&
+				/permission denied/i.test(err.message) &&
+				err.message.includes(join(dir, "dist", "server.js")),
+		);
+	} finally {
+		// Restore perms so afterEach's rm() can clean up.
+		await chmod(distDir, 0o755);
+	}
+});
+
+test("relative ../path also routes through local resolution", async () => {
+	// "../something" is a valid local-path prefix per isLocalPath. We don't
+	// need to construct a real ../something test fixture; the assertion is
+	// that the spec is recognized as a local path and produces a path-based
+	// error (not handed off to npx).
+	await assert.rejects(
+		resolveAdapter(adapterConfig("../never-exists-mcpaql-test")),
+		(err) =>
+			err instanceof Error &&
+			/expected/.test(err.message) &&
+			err.message.includes(join("dist", "server.js")),
 	);
 });
 

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -111,6 +111,18 @@ test("plain (unscoped) npm package name → npx --yes <package>", async () => {
 	assert.deepEqual(r.args, ["--yes", "some-package"]);
 });
 
+test("version-pinned scoped package @scope/name@1.2.3 → npx --yes (passes regex check)", async () => {
+	const r = await resolveAdapter(adapterConfig("@mcpaql/foo@2.1.0"));
+	assert.equal(r.command, "npx");
+	assert.deepEqual(r.args, ["--yes", "@mcpaql/foo@2.1.0"]);
+});
+
+test("version-pinned unscoped package pkg@1.0.0 → npx --yes", async () => {
+	const r = await resolveAdapter(adapterConfig("some-package@1.0.0"));
+	assert.equal(r.command, "npx");
+	assert.deepEqual(r.args, ["--yes", "some-package@1.0.0"]);
+});
+
 test("ambiguous unrooted path-like spec → throws with explicit guidance", async () => {
 	// "adapters/my-server" looks like a relative path but isn't rooted with
 	// ./, ../, ~/, or /. Without rejection, this would silently resolve to

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -83,6 +83,17 @@ test("permission denied on entry → distinguishes EACCES from missing file", as
 	}
 });
 
+test("bare .. routes through local resolution (not silent npx ..)", async () => {
+	// Without the explicit ".." check in isLocalPath, ".." has no slash so
+	// the ambiguous-slash guard wouldn't fire, and it doesn't startsWith
+	// "../" — it would silently fall through to `npx --yes ..`. Pin the
+	// behavior down: bare ".." is treated as a local path.
+	await assert.rejects(
+		resolveAdapter(adapterConfig("..")),
+		(err) => err instanceof Error && /expected/.test(err.message),
+	);
+});
+
 test("relative ../path also routes through local resolution", async () => {
 	// "../something" is a valid local-path prefix per isLocalPath. We don't
 	// need to construct a real ../something test fixture; the assertion is

--- a/test/resolve.test.mjs
+++ b/test/resolve.test.mjs
@@ -57,11 +57,10 @@ test("absolute path with no dist/server.js → throws with the expected entry pa
 	);
 });
 
-test("permission denied on entry → distinguishes EACCES from missing file", async (t) => {
-	// chmod 000 on a file makes access(F_OK) succeed but access(R_OK) fail
-	// on POSIX — node's fs/promises access checks F_OK by default, so to
-	// trigger EACCES we need to drop permissions on the parent directory
-	// instead. CI runners running as root bypass perms entirely; skip there.
+test("permission denied on parent dir → EACCES surfaces with distinct message", async (t) => {
+	// chmod 0 on the parent dir blocks the access() probe regardless of the
+	// entry file's own perms. CI runners running as root bypass POSIX perms
+	// entirely; skip there.
 	if (process.getuid && process.getuid() === 0) {
 		t.skip("skipped: running as root, perms bypassed");
 		return;
@@ -78,9 +77,44 @@ test("permission denied on entry → distinguishes EACCES from missing file", as
 				err.message.includes(join(dir, "dist", "server.js")),
 		);
 	} finally {
-		// Restore perms so afterEach's rm() can clean up.
 		await chmod(distDir, 0o755);
 	}
+});
+
+test("permission denied on entry FILE → EACCES (R_OK probe, not F_OK)", async (t) => {
+	// This is the case the F_OK → R_OK change actually fixes. With F_OK
+	// (existence-only), a mode-000 file would have passed the probe and
+	// failed only at `node` spawn time. With R_OK, mode-000 yields EACCES
+	// up front so the user gets the helpful message instead of a runtime
+	// surprise. Skip on root since perms are bypassed.
+	if (process.getuid && process.getuid() === 0) {
+		t.skip("skipped: running as root, perms bypassed");
+		return;
+	}
+	const dir = await makeAdapterDir(workdir);
+	const entry = join(dir, "dist", "server.js");
+	await chmod(entry, 0o000);
+	try {
+		await assert.rejects(
+			resolveAdapter(adapterConfig(dir)),
+			(err) =>
+				err instanceof Error &&
+				/permission denied/i.test(err.message) &&
+				err.message.includes(entry),
+		);
+	} finally {
+		await chmod(entry, 0o644);
+	}
+});
+
+test("bare . routes through local resolution (not silent npx .)", async () => {
+	// Same justification as bare "..": no slash so the ambiguous-slash guard
+	// doesn't fire, and it's not an existing isLocalPath prefix. Without the
+	// explicit equality check, "." would silently fall through to `npx --yes .`.
+	await assert.rejects(
+		resolveAdapter(adapterConfig(".")),
+		(err) => err instanceof Error && /expected/.test(err.message),
+	);
 });
 
 test("bare .. routes through local resolution (not silent npx ..)", async () => {
@@ -196,14 +230,14 @@ test("multi-segment scoped-package-shaped spec is also ambiguous", async () => {
 	);
 });
 
-test("git: URL → throws not-yet-implemented with mention of #6", async () => {
+test("git: URL → throws not-yet-implemented with mention of #31", async () => {
 	await assert.rejects(
 		resolveAdapter(adapterConfig("git:github.com/user/repo@v1")),
 		(err) =>
 			err instanceof Error &&
 			/git:/.test(err.message) &&
 			/not yet implemented/.test(err.message) &&
-			/#6/.test(err.message),
+			/#31/.test(err.message),
 	);
 });
 


### PR DESCRIPTION
## Summary
Implements `kind="adapter"` config resolution. Two of three adapter spec shapes from #6 land here; git URLs deferred to #31.

- **Local paths** (absolute, `./relative`, `~/home`, Windows drives) → `node <path>/dist/server.js`. fs.access() up-front so missing builds surface as actionable errors.
- **npm packages** (anything else not git:) → `npx --yes <pkg>`. npx handles cache + install automatically.
- **git URLs** (`git:` / `git+`) → throw with explicit "not yet implemented; see #31" message.

`src/index.ts` reverts the previous "kind=adapter is not implemented" notice path; `spawnAndRegister` now branches on `server.kind` to pick either the inline command (direct) or the resolved spawn (adapter).

After this lands, **#15 (DollhouseMCP via `npx @dollhousemcp/mcp-server`) becomes a config-only PR** — no further code changes needed.

## Test plan
- [x] `npm test` — 46/46 passing locally (38 existing + 8 new in `test/resolve.test.mjs`)
- [x] Typecheck clean
- [x] Build clean
- [ ] CI green on this PR
- [ ] Claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)