### PR TITLE
Wire DollhouseMCP into pi-bridge (direct mode) (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Configured via `~/.pi/mcpaql.config.json`:
       "name": "dollhouse",
       "transport": "stdio",
       "command": "npx",
-      "args": ["@dollhousemcp/mcp-server"],
+      "args": ["--yes", "@dollhousemcp/mcp-server"],
       "direct": true,
       "trust": "developer",
       "endpointMode": "multi"
@@ -57,7 +57,8 @@ Configured via `~/.pi/mcpaql.config.json`:
       "name": "github",
       "adapter": "@mcpaql/generated-github-mcp",
       "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${env:GITHUB_TOKEN}" },
-      "trust": "user"
+      "trust": "user",
+      "endpointMode": "multi"
     }
   ]
 }
@@ -95,7 +96,7 @@ The `dist/server.js` entry-point is convention; per-adapter entry overrides (or 
    cp examples/mcpaql.config.example.json ~/.pi/mcpaql.config.json
    ```
 
-2. **Trim it down to just the dollhouse entry** for now (the example also ships a `github` block that points at a placeholder local path; remove or repoint that one before launching pi):
+   The example ships only the dollhouse entry, so it's runnable as-is. For reference, the file looks like:
 
    ```jsonc
    {
@@ -113,15 +114,17 @@ The `dist/server.js` entry-point is convention; per-adapter entry overrides (or 
    }
    ```
 
-3. **Smoke-test the wiring** without booting pi:
+   `trust: "developer"` reduces gatekeeper-confirmation friction for this demo. For day-to-day workflows that touch destructive operations (`delete_element`, `clear`, `clear_github_auth`), drop to `"user"` — the loader's default — so dollhouse's gatekeeper prompts before each destructive call.
+
+2. **Smoke-test the wiring** without booting pi:
 
    ```bash
    npm run smoke:dollhouse
    ```
 
-   This spawns `npx --yes @dollhousemcp/mcp-server`, calls `read/introspect`, and prints the operations list. First run pulls the package; subsequent runs hit the npx cache.
+   This spawns `npx --yes @dollhousemcp/mcp-server@2.0.32`, calls `read/introspect`, and prints the operations list. First run pulls the package; subsequent runs hit the npx cache. Override the pin with `DOLLHOUSE_PKG=@dollhousemcp/mcp-server` to smoke against the latest published version.
 
-4. **Launch pi** with the bridge as an extension. Once registered, the LLM sees `dollhouse_create` / `dollhouse_read` / `dollhouse_update` / `dollhouse_delete` / `dollhouse_execute` and can call `dollhouse_read introspect` to discover what dollhouse offers.
+3. **Launch pi** with the bridge as an extension. Once registered, the LLM sees `dollhouse_create` / `dollhouse_read` / `dollhouse_update` / `dollhouse_delete` / `dollhouse_execute` and can call `dollhouse_read introspect` to discover what dollhouse offers.
 
 ### Adapter-mode equivalent
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,64 @@ The `dist/server.js` entry-point is convention; per-adapter entry overrides (or 
 
 > **Platform note.** Windows drive-letter paths (e.g. `C:\path\to\adapter`) are recognized as a local-path shape so Windows users get a sensible error message rather than silent dispatch to npx, but the supported runtime for this package is Node 20+ on Linux/macOS. Windows is not on the release matrix.
 
+## Quick start with DollhouseMCP
+
+[DollhouseMCP](https://github.com/DollhouseMCP/mcp-server) speaks MCP-AQL natively, so you can wire it up without writing or generating an adapter. This is the fastest way to see the bridge end-to-end against a real server.
+
+1. **Copy the example config** to where the bridge looks for it:
+
+   ```bash
+   mkdir -p ~/.pi
+   cp examples/mcpaql.config.example.json ~/.pi/mcpaql.config.json
+   ```
+
+2. **Trim it down to just the dollhouse entry** for now (the example also ships a `github` block that points at a placeholder local path; remove or repoint that one before launching pi):
+
+   ```jsonc
+   {
+     "servers": [
+       {
+         "name": "dollhouse",
+         "transport": "stdio",
+         "command": "npx",
+         "args": ["--yes", "@dollhousemcp/mcp-server"],
+         "direct": true,
+         "trust": "developer",
+         "endpointMode": "multi"
+       }
+     ]
+   }
+   ```
+
+3. **Smoke-test the wiring** without booting pi:
+
+   ```bash
+   npm run smoke:dollhouse
+   ```
+
+   This spawns `npx --yes @dollhousemcp/mcp-server`, calls `read/introspect`, and prints the operations list. First run pulls the package; subsequent runs hit the npx cache.
+
+4. **Launch pi** with the bridge as an extension. Once registered, the LLM sees `dollhouse_create` / `dollhouse_read` / `dollhouse_update` / `dollhouse_delete` / `dollhouse_execute` and can call `dollhouse_read introspect` to discover what dollhouse offers.
+
+### Adapter-mode equivalent
+
+Same upstream, slightly different config shape — uses #6's npm resolver instead of `direct`:
+
+```jsonc
+{
+  "name": "dollhouse",
+  "adapter": "@dollhousemcp/mcp-server",
+  "trust": "developer",
+  "endpointMode": "multi"
+}
+```
+
+Both forms end up running `npx @dollhousemcp/mcp-server` as a stdio child. The `direct: true` form is canonical for natively-MCP-AQL servers; the `adapter:` form is the same npm-resolution path generated adapters use.
+
+### Known conformance gaps
+
+Live `read/introspect` against `@dollhousemcp/mcp-server` returns operations whose summary objects use `element_name` instead of the spec's `name` field. The bridge's discriminated-response envelope (`{ success, data }`) still validates, so call-and-response works end-to-end, but `OperationInfo`-shape strict validation flags this. The conformance test in `test/conformance-dollhouse.test.mjs` asserts both states (envelope passes, strict shape fails) and serves as a regression marker — when DollhouseMCP closes the gap, that test will need a fixture refresh.
+
 ## Installation
 
 > Not yet published. Until then, see the issues for the walking-skeleton plan.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Configured via `~/.pi/mcpaql.config.json`:
 
 - `direct: true` — server already speaks MCP-AQL natively; talk straight to its `mcp_aql_*` tools. Requires `command` and `args`.
 - `adapter: "<spec>"` — wrap a non-MCP-AQL server with a generated adapter, then expose that. The spec recognizes three forms (see *Adapter spec forms* below).
-- `endpointMode: "multi" | "unified"` — 5 separate Pi tools per server, or 1 unified tool with the operation name in params.
-- `trust` — gatekeeper trust level for this server (`untrusted` / `user` / `developer` / `admin`).
+- `endpointMode: "multi" | "unified"` — 5 separate Pi tools per server, or 1 unified tool with the operation name in params. Defaults to `"multi"`; shown explicitly above for clarity.
+- `trust` — gatekeeper trust level for this server (`untrusted` / `user` / `developer` / `admin`). Defaults to `"user"`.
 
 ### Adapter spec forms
 

--- a/examples/mcpaql.config.example.json
+++ b/examples/mcpaql.config.example.json
@@ -1,0 +1,20 @@
+{
+  "servers": [
+    {
+      "name": "dollhouse",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["--yes", "@dollhousemcp/mcp-server"],
+      "direct": true,
+      "trust": "developer",
+      "endpointMode": "multi"
+    },
+    {
+      "name": "github",
+      "adapter": "/absolute/path/to/your/adapter",
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${env:GITHUB_TOKEN}" },
+      "trust": "user",
+      "endpointMode": "multi"
+    }
+  ]
+}

--- a/examples/mcpaql.config.example.json
+++ b/examples/mcpaql.config.example.json
@@ -8,13 +8,6 @@
       "direct": true,
       "trust": "developer",
       "endpointMode": "multi"
-    },
-    {
-      "name": "github",
-      "adapter": "/absolute/path/to/your/adapter",
-      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${env:GITHUB_TOKEN}" },
-      "trust": "user",
-      "endpointMode": "multi"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "pretest": "npm run build",
     "test": "node --test test/*.test.mjs",
+    "presmoke:dollhouse": "npm run build",
+    "smoke:dollhouse": "node scripts/smoke-dollhouse.mjs",
     "test:docker": "docker build -t mcpaql-pi-bridge-test . && docker run --rm mcpaql-pi-bridge-test",
     "test:docker:shell": "docker build -t mcpaql-pi-bridge-test . && docker run --rm -it mcpaql-pi-bridge-test bash",
     "test:matrix": "bash scripts/test-matrix.sh"

--- a/scripts/smoke-dollhouse.mjs
+++ b/scripts/smoke-dollhouse.mjs
@@ -12,21 +12,31 @@
  *   npm run smoke:dollhouse
  *
  * Environment:
- *   DOLLHOUSE_PKG  — override the package spec (default: @dollhousemcp/mcp-server)
+ *   DOLLHOUSE_PKG  — override the pinned package spec (default below)
+ *
+ * The default is pinned to the version that produced the captured
+ * conformance fixture (test/fixtures/dollhouse-introspect.json) so smoke
+ * output stays in sync with the fixture by default. Use DOLLHOUSE_PKG to
+ * smoke against `@latest` before bumping the fixture.
  */
 //
-// Expected shape of a healthy run (truncated):
+// Expected shape of a healthy run (truncated). Note operation summaries
+// use `element_name` rather than the spec's `name` — that's the dollhouse
+// conformance gap pinned by test/conformance-dollhouse.test.mjs (#23).
 //   {
 //     "success": true,
 //     "data": {
-//       "_protocol": { "version": "...", "mode": "crude" },
-//       "operations": [ { "name": "list_elements", "endpoint": "READ", ... }, ... ]
+//       "operations": [
+//         { "element_name": "list_elements", "endpoint": "READ", ... },
+//         ...
+//       ]
 //     }
 //   }
 
 import { spawnHost } from "../dist/host.js";
 
-const PKG = process.env.DOLLHOUSE_PKG ?? "@dollhousemcp/mcp-server";
+const DEFAULT_PKG = "@dollhousemcp/mcp-server@2.0.32";
+const PKG = process.env.DOLLHOUSE_PKG ?? DEFAULT_PKG;
 
 const config = {
 	name: "dollhouse",
@@ -35,7 +45,8 @@ const config = {
 };
 
 async function main() {
-	console.log(`[smoke] spawning ${config.name} via npx ${PKG}…`);
+	console.log(`[smoke] package spec: ${PKG}${PKG === DEFAULT_PKG ? "" : " (overridden via DOLLHOUSE_PKG)"}`);
+	console.log(`[smoke] spawning ${config.name} via npx…`);
 	const host = await spawnHost(config);
 	console.log(`[smoke] connected. calling read/introspect…`);
 

--- a/scripts/smoke-dollhouse.mjs
+++ b/scripts/smoke-dollhouse.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Smoke-tests the bridge against a live DollhouseMCP server (direct mode).
+ *
+ * DollhouseMCP speaks MCP-AQL natively, so no adapter is needed — spawnHost
+ * talks straight to its mcp_aql_* tools. This script spawns it via npx,
+ * calls read/introspect, prints the operations list, and exits 0 on success.
+ *
+ * Not run in CI — depends on the npm registry and pulls a several-MB package
+ * the first time. Run it manually after wiring changes:
+ *
+ *   npm run smoke:dollhouse
+ *
+ * Environment:
+ *   DOLLHOUSE_PKG  — override the package spec (default: @dollhousemcp/mcp-server)
+ */
+//
+// Expected shape of a healthy run (truncated):
+//   {
+//     "success": true,
+//     "data": {
+//       "_protocol": { "version": "...", "mode": "crude" },
+//       "operations": [ { "name": "list_elements", "endpoint": "READ", ... }, ... ]
+//     }
+//   }
+
+import { spawnHost } from "../dist/host.js";
+
+const PKG = process.env.DOLLHOUSE_PKG ?? "@dollhousemcp/mcp-server";
+
+const config = {
+	name: "dollhouse",
+	command: "npx",
+	args: ["--yes", PKG],
+};
+
+async function main() {
+	console.log(`[smoke] spawning ${config.name} via npx ${PKG}…`);
+	const host = await spawnHost(config);
+	console.log(`[smoke] connected. calling read/introspect…`);
+
+	try {
+		const response = await host.call("read", "introspect", { query: "operations" });
+		const json = JSON.stringify(response, null, 2);
+		// Print full response so a maintainer can spot-check shape regressions.
+		console.log(`[smoke] response:\n${json}`);
+
+		if (!response.success) {
+			console.error(`[smoke] FAIL — response.success=false`);
+			process.exitCode = 1;
+			return;
+		}
+
+		const data = /** @type {{ operations?: unknown[] }} */ (response.data);
+		const ops = Array.isArray(data?.operations) ? data.operations : [];
+		if (ops.length === 0) {
+			console.error(`[smoke] FAIL — operations array is empty`);
+			process.exitCode = 1;
+			return;
+		}
+		console.log(`[smoke] OK — ${ops.length} operations advertised.`);
+	} finally {
+		await host.close();
+	}
+}
+
+main().catch((err) => {
+	console.error(`[smoke] threw:`, err);
+	process.exit(1);
+});

--- a/scripts/smoke-dollhouse.mjs
+++ b/scripts/smoke-dollhouse.mjs
@@ -38,6 +38,12 @@ import { spawnHost } from "../dist/host.js";
 const DEFAULT_PKG = "@dollhousemcp/mcp-server@2.0.32";
 const PKG = process.env.DOLLHOUSE_PKG ?? DEFAULT_PKG;
 
+// spawnHost consumes the narrow HostSpawnConfig (name/command/args/env only).
+// The richer shape from a real ~/.pi/mcpaql.config.json — `direct: true`,
+// `transport`, `trust`, `endpointMode` — lives on ResolvedServerConfig in
+// src/config.ts and is consumed by the entrypoint, not the host. Mirroring
+// those fields here would be silently dropped, so we omit them and document
+// that the smoke exercises only the spawn-and-call layer.
 const config = {
 	name: "dollhouse",
 	command: "npx",

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -219,24 +219,22 @@ test("unknown server field is rejected (additionalProperties: false)", async () 
 
 test("examples/mcpaql.config.example.json parses against MCPAQL_CONFIG_SCHEMA", async () => {
 	// Catches drift between the documented example and the loader's schema —
-	// the README walkthrough copies this file into ~/.pi/, so it must stay
-	// schema-valid even though the github adapter path is a placeholder.
+	// the README walkthrough copies this file into ~/.pi/ unedited, so it must
+	// stay schema-valid AND zero-config-runnable. loadConfig validates shape
+	// only; adapter-path filesystem checks happen at spawn time (resolve.ts),
+	// so this test runs anywhere regardless of paths in the file.
 	const examplePath = join(REPO_ROOT, "examples", "mcpaql.config.example.json");
 	const r = await loadConfig(examplePath);
 	assert.equal(r.loaded, true);
-	assert.equal(r.servers.length, 2);
+	assert.equal(r.servers.length, 1);
 
-	const dollhouse = r.servers.find((s) => s.name === "dollhouse");
-	assert.ok(dollhouse, "expected a 'dollhouse' server in the example");
+	const dollhouse = r.servers[0];
+	assert.equal(dollhouse.name, "dollhouse");
 	assert.equal(dollhouse.kind, "direct");
 	assert.equal(dollhouse.command, "npx");
 	assert.deepEqual(dollhouse.args, ["--yes", "@dollhousemcp/mcp-server"]);
 	assert.equal(dollhouse.trust, "developer");
 	assert.equal(dollhouse.endpointMode, "multi");
-
-	const github = r.servers.find((s) => s.name === "github");
-	assert.ok(github, "expected a 'github' server in the example");
-	assert.equal(github.kind, "adapter");
 });
 
 test("dollhouse direct-mode shape from the README parses as documented", async () => {

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -6,10 +6,14 @@
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, test } from "node:test";
 
 import { ConfigError, loadConfig } from "../dist/config.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
 
 let workdir;
 let cfgPath;
@@ -211,4 +215,55 @@ test("unknown server field is rejected (additionalProperties: false)", async () 
 		servers: [{ name: "foo", direct: true, command: "x", bogus: 1 }],
 	});
 	await assert.rejects(loadConfig(cfgPath), ConfigError);
+});
+
+test("examples/mcpaql.config.example.json parses against MCPAQL_CONFIG_SCHEMA", async () => {
+	// Catches drift between the documented example and the loader's schema —
+	// the README walkthrough copies this file into ~/.pi/, so it must stay
+	// schema-valid even though the github adapter path is a placeholder.
+	const examplePath = join(REPO_ROOT, "examples", "mcpaql.config.example.json");
+	const r = await loadConfig(examplePath);
+	assert.equal(r.loaded, true);
+	assert.equal(r.servers.length, 2);
+
+	const dollhouse = r.servers.find((s) => s.name === "dollhouse");
+	assert.ok(dollhouse, "expected a 'dollhouse' server in the example");
+	assert.equal(dollhouse.kind, "direct");
+	assert.equal(dollhouse.command, "npx");
+	assert.deepEqual(dollhouse.args, ["--yes", "@dollhousemcp/mcp-server"]);
+	assert.equal(dollhouse.trust, "developer");
+	assert.equal(dollhouse.endpointMode, "multi");
+
+	const github = r.servers.find((s) => s.name === "github");
+	assert.ok(github, "expected a 'github' server in the example");
+	assert.equal(github.kind, "adapter");
+});
+
+test("dollhouse direct-mode shape from the README parses as documented", async () => {
+	// Locks in the canonical dollhouse direct-mode block. If the README's
+	// quick-start snippet drifts from what the loader accepts, this fails
+	// before users hit the loader's error path.
+	await writeCfg({
+		servers: [
+			{
+				name: "dollhouse",
+				transport: "stdio",
+				command: "npx",
+				args: ["--yes", "@dollhousemcp/mcp-server"],
+				direct: true,
+				trust: "developer",
+				endpointMode: "multi",
+			},
+		],
+	});
+	const r = await loadConfig(cfgPath);
+	assert.equal(r.servers.length, 1);
+	const s = r.servers[0];
+	assert.equal(s.kind, "direct");
+	assert.equal(s.name, "dollhouse");
+	assert.equal(s.transport, "stdio");
+	assert.equal(s.command, "npx");
+	assert.deepEqual(s.args, ["--yes", "@dollhousemcp/mcp-server"]);
+	assert.equal(s.trust, "developer");
+	assert.equal(s.endpointMode, "multi");
 });

--- a/test/conformance-dollhouse.test.mjs
+++ b/test/conformance-dollhouse.test.mjs
@@ -1,0 +1,87 @@
+/**
+ * Spec-conformance check against a captured DollhouseMCP introspection
+ * response. Validates two things:
+ *
+ *   1. The discriminated-response envelope (operation-result.schema) — must
+ *      pass. The bridge relies on this shape; if it ever fails, dollhouse
+ *      stopped being an MCP-AQL server and this is a hard regression.
+ *
+ *   2. The strict introspection-response.schema — currently FAILS for
+ *      dollhouse. Operation summaries use `element_name` instead of the
+ *      spec's `name`, which trips both `additionalProperties: false` and
+ *      the `required: ["name", ...]` constraint on OperationInfo.
+ *
+ * Asserting both states pins the known conformance gap: when DollhouseMCP
+ * closes it, this test fails noisily and signals "refresh the fixture and
+ * flip the assertion." Tracked in the deferred conformance issue (#23).
+ *
+ * Fixture provenance: captured by `npm run smoke:dollhouse` against
+ * `@dollhousemcp/mcp-server@2.0.32` on 2026-04-29. Re-capture with the
+ * smoke script when bumping the dollhouse version.
+ */
+
+import { readFile } from "node:fs/promises";
+import assert from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+
+const AjvCtor = Ajv2020.default ?? Ajv2020;
+const addFormatsFn = addFormats.default ?? addFormats;
+
+const ajv = new AjvCtor({ strict: false, allErrors: true });
+addFormatsFn(ajv);
+
+const operationResultSchema = JSON.parse(
+	await readFile(resolve(ROOT, "conformance/schemas/operation-result.schema.json"), "utf8"),
+);
+const introspectionResponseSchema = JSON.parse(
+	await readFile(resolve(ROOT, "conformance/schemas/introspection-response.schema.json"), "utf8"),
+);
+
+const validateOperationResult = ajv.compile(operationResultSchema);
+const validateIntrospectionResponse = ajv.compile(introspectionResponseSchema);
+
+const fixture = JSON.parse(
+	await readFile(resolve(HERE, "fixtures/dollhouse-introspect.json"), "utf8"),
+);
+
+test("dollhouse introspection envelope conforms to operation-result", () => {
+	const ok = validateOperationResult(fixture);
+	if (!ok) {
+		const errs = (validateOperationResult.errors ?? [])
+			.map((e) => `${e.instancePath} ${e.message}`)
+			.join("; ");
+		assert.fail(`envelope rejected by operation-result schema: ${errs}`);
+	}
+	assert.equal(fixture.success, true);
+	assert.ok(Array.isArray(fixture.data?.operations), "expected operations array");
+	assert.ok(fixture.data.operations.length > 0, "expected non-empty operations array");
+});
+
+test("dollhouse introspection currently fails strict introspection-response (documents gap)", () => {
+	const ok = validateIntrospectionResponse(fixture);
+	assert.equal(
+		ok,
+		false,
+		"dollhouse introspection unexpectedly passed strict schema — refresh the fixture and flip this assertion (#23 closed?)",
+	);
+
+	const errors = validateIntrospectionResponse.errors ?? [];
+	// At least one error must be about the OperationInfo shape — i.e. the
+	// `element_name` / missing `name` divergence. If the failure mode shifts
+	// to something else, that's also worth catching here.
+	const operationInfoErrors = errors.filter((e) =>
+		/operations/.test(e.instancePath ?? ""),
+	);
+	assert.ok(
+		operationInfoErrors.length > 0,
+		`expected schema errors on the operations array, got: ${JSON.stringify(errors)}`,
+	);
+});

--- a/test/conformance-dollhouse.test.mjs
+++ b/test/conformance-dollhouse.test.mjs
@@ -35,6 +35,11 @@ const ROOT = resolve(HERE, "..");
 const AjvCtor = Ajv2020.default ?? Ajv2020;
 const addFormatsFn = addFormats.default ?? addFormats;
 
+// strict: false — accept the spec's `examples` keyword on schemas without
+// AJV erroring (it's a JSON Schema 2020-12 vocabulary keyword AJV doesn't
+// know about). allErrors: true — collect every violation so the gap test
+// below can find the specific one it's pinning instead of stopping at the
+// first.
 const ajv = new AjvCtor({ strict: false, allErrors: true });
 addFormatsFn(ajv);
 
@@ -73,15 +78,24 @@ test("dollhouse introspection currently fails strict introspection-response (doc
 		"dollhouse introspection unexpectedly passed strict schema — refresh the fixture and flip this assertion (#23 closed?)",
 	);
 
+	// Pin the SPECIFIC failure mode (the `element_name` divergence) rather
+	// than "any operations-level error" — otherwise a future fix to
+	// `element_name` could land alongside an unrelated new violation and
+	// the test would stay green for the wrong reason.
 	const errors = validateIntrospectionResponse.errors ?? [];
-	// At least one error must be about the OperationInfo shape — i.e. the
-	// `element_name` / missing `name` divergence. If the failure mode shifts
-	// to something else, that's also worth catching here.
-	const operationInfoErrors = errors.filter((e) =>
-		/operations/.test(e.instancePath ?? ""),
-	);
+	const elementNameErrors = errors.filter((e) => {
+		const onOperationsItem = /^\/data\/operations\/\d+/.test(e.instancePath ?? "");
+		if (!onOperationsItem) return false;
+		if (e.keyword === "additionalProperties" && e.params?.additionalProperty === "element_name") {
+			return true;
+		}
+		if (e.keyword === "required" && e.params?.missingProperty === "name") {
+			return true;
+		}
+		return false;
+	});
 	assert.ok(
-		operationInfoErrors.length > 0,
-		`expected schema errors on the operations array, got: ${JSON.stringify(errors)}`,
+		elementNameErrors.length > 0,
+		`expected the element_name/name divergence on operations items; got: ${JSON.stringify(errors)}`,
 	);
 });

--- a/test/conformance-dollhouse.test.mjs
+++ b/test/conformance-dollhouse.test.mjs
@@ -15,9 +15,11 @@
  * closes it, this test fails noisily and signals "refresh the fixture and
  * flip the assertion." Tracked in the deferred conformance issue (#23).
  *
- * Fixture provenance: captured by `npm run smoke:dollhouse` against
- * `@dollhousemcp/mcp-server@2.0.32` on 2026-04-29. Re-capture with the
- * smoke script when bumping the dollhouse version.
+ * Fixture provenance: captured by `npm run smoke:dollhouse` against the
+ * `DEFAULT_PKG` pinned in scripts/smoke-dollhouse.mjs (was
+ * `@dollhousemcp/mcp-server@2.0.32` on 2026-04-29). Re-capture when bumping
+ * `DEFAULT_PKG` — the smoke script is the single source of truth for the
+ * pinned version.
  */
 
 import { readFile } from "node:fs/promises";

--- a/test/fixtures/dollhouse-introspect.json
+++ b/test/fixtures/dollhouse-introspect.json
@@ -1,0 +1,387 @@
+{
+  "success": true,
+  "data": {
+    "operations": [
+      {
+        "element_name": "addEntry",
+        "endpoint": "CREATE",
+        "description": "Add a new entry to a memory element"
+      },
+      {
+        "element_name": "beetlejuice_beetlejuice_beetlejuice",
+        "endpoint": "CREATE",
+        "description": "Safe-trigger the full danger zone verification pipeline for testing purposes"
+      },
+      {
+        "element_name": "configure_oauth",
+        "endpoint": "CREATE",
+        "description": "Configure GitHub OAuth client ID"
+      },
+      {
+        "element_name": "create_element",
+        "endpoint": "CREATE",
+        "description": "Create a new element of any type. Note: Gatekeeper may return a confirmation prompt instead of creating immediately — use confirm_operation to approve, then retry."
+      },
+      {
+        "element_name": "import_element",
+        "endpoint": "CREATE",
+        "description": "Import an element from exported data"
+      },
+      {
+        "element_name": "import_persona",
+        "endpoint": "CREATE",
+        "description": "Import a persona from a file path or JSON string"
+      },
+      {
+        "element_name": "init_portfolio",
+        "endpoint": "CREATE",
+        "description": "Initialize a new GitHub portfolio repository"
+      },
+      {
+        "element_name": "install_collection_content",
+        "endpoint": "CREATE",
+        "description": "Install an element from the collection to your local portfolio"
+      },
+      {
+        "element_name": "portfolio_element_manager",
+        "endpoint": "CREATE",
+        "description": "Manage individual elements between local and GitHub"
+      },
+      {
+        "element_name": "record_execution_step",
+        "endpoint": "CREATE",
+        "description": "Record execution progress, step completion, or findings. This is the normal follow-up call after execute_agent. Returns autonomy directive with continue/pause decision and notifications."
+      },
+      {
+        "element_name": "release_deadlock",
+        "endpoint": "CREATE",
+        "description": "Recover from a restrictive permission deadlock by showing a human-only verification code, then deactivating all active elements and clearing current-session activation state"
+      },
+      {
+        "element_name": "setup_github_auth",
+        "endpoint": "CREATE",
+        "description": "Set up GitHub authentication using device flow"
+      },
+      {
+        "element_name": "submit_collection_content",
+        "endpoint": "CREATE",
+        "description": "Submit a local element to the community collection via GitHub"
+      },
+      {
+        "element_name": "sync_portfolio",
+        "endpoint": "CREATE",
+        "description": "Sync local portfolio with GitHub repository"
+      },
+      {
+        "element_name": "verify_challenge",
+        "endpoint": "CREATE",
+        "description": "Submit verification code to unblock a danger zone operation"
+      },
+      {
+        "element_name": "activate_element",
+        "endpoint": "READ",
+        "description": "Activate an element for use in the current session. Activation state is persisted per-session (DOLLHOUSE_SESSION_ID) and restored on server restart."
+      },
+      {
+        "element_name": "browse_collection",
+        "endpoint": "READ",
+        "description": "Browse the DollhouseMCP community collection by section and type"
+      },
+      {
+        "element_name": "check_github_auth",
+        "endpoint": "READ",
+        "description": "Check current GitHub authentication status"
+      },
+      {
+        "element_name": "convert_skill_format",
+        "endpoint": "READ",
+        "description": "Convert between current Agent Skill and Dollhouse Skill formats (both directions) with structured warnings and optional roundtrip state for lossless supported-field restoration"
+      },
+      {
+        "element_name": "deactivate_element",
+        "endpoint": "READ",
+        "description": "Deactivate an element, removing it from the current session. Persisted activation state is updated."
+      },
+      {
+        "element_name": "dollhouse_config",
+        "endpoint": "READ",
+        "description": "Manage DollhouseMCP configuration settings"
+      },
+      {
+        "element_name": "evaluate_permission",
+        "endpoint": "READ",
+        "description": "Evaluate CLI permission for a tool via HTTP/hook. Returns platform-formatted response (claude_code, gemini, cursor, windsurf, codex). Alternative to permission_prompt for interactive sessions using PreToolUse hooks."
+      },
+      {
+        "element_name": "export_element",
+        "endpoint": "READ",
+        "description": "Export an element to a portable format"
+      },
+      {
+        "element_name": "find_similar_elements",
+        "endpoint": "READ",
+        "description": "Find semantically similar elements using NLP scoring"
+      },
+      {
+        "element_name": "get_active_elements",
+        "endpoint": "READ",
+        "description": "Get all currently active elements with rendered content, optionally filtered by type"
+      },
+      {
+        "element_name": "get_build_info",
+        "endpoint": "READ",
+        "description": "Get comprehensive build and runtime information"
+      },
+      {
+        "element_name": "get_cache_budget_report",
+        "endpoint": "READ",
+        "description": "Get global cache memory budget report with per-cache diagnostics"
+      },
+      {
+        "element_name": "get_capabilities",
+        "endpoint": "READ",
+        "description": "Get a high-level map of all server capabilities grouped by user intent. Returns brief descriptions of every available operation organized by category. Use introspect for full details on any specific operation."
+      },
+      {
+        "element_name": "get_collection_cache_health",
+        "endpoint": "READ",
+        "description": "Get health status and statistics for the collection cache"
+      },
+      {
+        "element_name": "get_collection_content",
+        "endpoint": "READ",
+        "description": "Get detailed information about content from the collection"
+      },
+      {
+        "element_name": "get_effective_cli_policies",
+        "endpoint": "READ",
+        "description": "Get effective CLI-level permission policies across all active elements"
+      },
+      {
+        "element_name": "get_element",
+        "endpoint": "READ",
+        "description": "Get a specific element by name. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead."
+      },
+      {
+        "element_name": "get_element_details",
+        "endpoint": "READ",
+        "description": "Get detailed information about a specific element including extended metadata. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead."
+      },
+      {
+        "element_name": "get_element_relationships",
+        "endpoint": "READ",
+        "description": "Get all relationships for a specific element"
+      },
+      {
+        "element_name": "get_execution_state",
+        "endpoint": "READ",
+        "description": "Query current execution state including progress and findings. Use the same element_name you passed to execute_agent for this execution."
+      },
+      {
+        "element_name": "get_gathered_data",
+        "endpoint": "READ",
+        "description": "Get aggregated execution data (steps, decisions, findings, and summary statistics) for a specific goal"
+      },
+      {
+        "element_name": "get_pending_cli_approvals",
+        "endpoint": "READ",
+        "description": "Get all pending CLI tool approval requests for this session. Returns unapproved requests that are waiting for human authorization."
+      },
+      {
+        "element_name": "get_permission_authority",
+        "endpoint": "READ",
+        "description": "Get the current permission-authority mode for supported hosts. Read-only: AI can inspect authority state but cannot change it."
+      },
+      {
+        "element_name": "get_relationship_stats",
+        "endpoint": "READ",
+        "description": "Get statistics about Enhanced Index relationships"
+      },
+      {
+        "element_name": "introspect",
+        "endpoint": "READ",
+        "description": "Query available operations, types, and element format specs for discovery"
+      },
+      {
+        "element_name": "introspect",
+        "endpoint": "READ",
+        "description": "Query available operations, types, and element format specs for discovery"
+      },
+      {
+        "element_name": "list_elements",
+        "endpoint": "READ",
+        "description": "List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending. TIP: If the user wants to browse, explore, or view their portfolio visually, prefer open_portfolio_browser instead — it opens a full web UI with search, filters, and detail views."
+      },
+      {
+        "element_name": "oauth_helper_status",
+        "endpoint": "READ",
+        "description": "Get diagnostic information about OAuth helper process"
+      },
+      {
+        "element_name": "open_logs",
+        "endpoint": "READ",
+        "description": "Open the management console directly on the logs tab. Supports URL parameters for pre-filtered views. Aliases: open_dollhouse_logs, open_dollhouse_mcp_logs."
+      },
+      {
+        "element_name": "open_metrics",
+        "endpoint": "READ",
+        "description": "Open the management console directly on the metrics tab. Supports URL parameters for filtered views. Aliases: open_dollhouse_metrics, open_dollhouse_mcp_metrics."
+      },
+      {
+        "element_name": "open_permissions",
+        "endpoint": "READ",
+        "description": "Open the management console directly on the permissions tab. Aliases: open_dollhouse_permissions."
+      },
+      {
+        "element_name": "open_portfolio_browser",
+        "endpoint": "READ",
+        "description": "Start the portfolio web UI and open it in the system browser. The web server runs on localhost:41715 and shows all portfolio elements with search, filtering, and detail views. Supports URL parameters for deep-linking with pre-populated search, filters, and element navigation. Aliases: open_console, open_management_console, open_dollhouse_mcp."
+      },
+      {
+        "element_name": "open_setup",
+        "endpoint": "READ",
+        "description": "Open the management console directly on the setup/install tab. Aliases: open_dollhouse_setup, open_installer."
+      },
+      {
+        "element_name": "permission_prompt",
+        "endpoint": "READ",
+        "description": "Evaluate a CLI-level permission prompt (Bash, Edit, Write, MCP tools). Returns allow/deny decision for non-interactive Claude Code sessions using --permission-prompt-tool."
+      },
+      {
+        "element_name": "portfolio_config",
+        "endpoint": "READ",
+        "description": "Configure portfolio settings (auto-sync, visibility, etc.)"
+      },
+      {
+        "element_name": "portfolio_status",
+        "endpoint": "READ",
+        "description": "Check GitHub portfolio repository status and element counts"
+      },
+      {
+        "element_name": "query_elements",
+        "endpoint": "READ",
+        "description": "Query elements with filters, sorting, pagination, and count aggregation. Returns structured JSON."
+      },
+      {
+        "element_name": "query_logs",
+        "endpoint": "READ",
+        "description": "Query recent log entries from the in-memory buffer. Returns filtered, paginated results sorted newest-first. Only queries the hot tier (in-memory); evicted entries exist only in disk log files."
+      },
+      {
+        "element_name": "query_metrics",
+        "endpoint": "READ",
+        "description": "Query collected metrics snapshots. Returns filtered, paginated results sorted newest-first. Supports filtering by metric name (prefix or exact), source, type, and time range."
+      },
+      {
+        "element_name": "render",
+        "endpoint": "READ",
+        "description": "Render a template with provided variables. For section-format templates (<template>, <style>, <script>), renders the <template> section by default — variable substitution only applies there. Use section: \"style\" or \"script\" to retrieve raw passthrough sections where }} is safe."
+      },
+      {
+        "element_name": "search",
+        "endpoint": "READ",
+        "description": "Unified search across local, GitHub, and collection sources with flexible scope"
+      },
+      {
+        "element_name": "search_all",
+        "endpoint": "READ",
+        "description": "Unified search across local, GitHub, and collection sources"
+      },
+      {
+        "element_name": "search_by_verb",
+        "endpoint": "READ",
+        "description": "Search for elements that handle a specific action verb"
+      },
+      {
+        "element_name": "search_collection",
+        "endpoint": "READ",
+        "description": "Search the community collection for elements by keywords"
+      },
+      {
+        "element_name": "search_collection_enhanced",
+        "endpoint": "READ",
+        "description": "Advanced search with pagination, filtering, and sorting"
+      },
+      {
+        "element_name": "search_elements",
+        "endpoint": "READ",
+        "description": "Full-text search across element names, descriptions, and content with pagination and sorting. TIP: If the user wants to browse or explore their portfolio visually rather than get text results, prefer open_portfolio_browser with a q parameter instead — it opens a web UI with the search pre-populated."
+      },
+      {
+        "element_name": "search_portfolio",
+        "endpoint": "READ",
+        "description": "Search local portfolio by content name, keywords, or tags"
+      },
+      {
+        "element_name": "validate_element",
+        "endpoint": "READ",
+        "description": "Validate an existing element by name"
+      },
+      {
+        "element_name": "edit_element",
+        "endpoint": "UPDATE",
+        "description": "Edit an element using GraphQL-aligned nested input objects"
+      },
+      {
+        "element_name": "upgrade_element",
+        "endpoint": "UPDATE",
+        "description": "Upgrade element from v1 single-body format to v2.0 dual-field format (instructions + content). Reads existing body text, assigns to instructions or content based on element type, saves in new format with instructions in YAML frontmatter."
+      },
+      {
+        "element_name": "clear",
+        "endpoint": "DELETE",
+        "description": "Clear all entries from a memory element (irreversible)"
+      },
+      {
+        "element_name": "clear_github_auth",
+        "endpoint": "DELETE",
+        "description": "Remove GitHub authentication and disconnect"
+      },
+      {
+        "element_name": "delete_element",
+        "endpoint": "DELETE",
+        "description": "Delete an element"
+      },
+      {
+        "element_name": "abort_execution",
+        "endpoint": "EXECUTE",
+        "description": "Abort a running agent execution, rejecting further operations for the goalId"
+      },
+      {
+        "element_name": "approve_cli_permission",
+        "endpoint": "EXECUTE",
+        "description": "Approve a pending CLI tool permission request. Used by bridges (Zulip, Slack) to relay human approval for tools that require it."
+      },
+      {
+        "element_name": "complete_execution",
+        "endpoint": "EXECUTE",
+        "description": "Signal that execution finished successfully with summary"
+      },
+      {
+        "element_name": "confirm_operation",
+        "endpoint": "EXECUTE",
+        "description": "Confirm a pending operation that requires user approval (Gatekeeper flow)"
+      },
+      {
+        "element_name": "continue_execution",
+        "endpoint": "EXECUTE",
+        "description": "Resume a previously paused execution from saved state. Use only after a pause or handoff boundary, not as the normal next call after execute_agent. Pass the same goal parameters used for execute_agent so the goal template can be revalidated before resuming."
+      },
+      {
+        "element_name": "execute_agent",
+        "endpoint": "EXECUTE",
+        "description": "Start execution of an agent. The agent must have a goal.template defined (set during create_element). Pass values for the template placeholders in parameters. Canonical loop: call execute_agent once to start, then use mcp_aql_create record_execution_step after each work chunk, inspect autonomy.continue and autonomy.notifications, and call complete_execution when done. continue_execution is only for resuming an already-paused execution and is not the normal next call after execute_agent. Lifecycle: Elements listed in the agent's activates field (e.g., activates: { personas: [\"Reviewer\"], skills: [\"code-analysis\"] }) are automatically activated when execution begins — their gatekeeper policies, instructions, and capabilities become active for the duration. Resilience: If the agent has a resilience policy, it governs automatic recovery during execution. onStepLimitReached (pause|continue|restart) controls what happens when maxAutonomousSteps is hit. onExecutionFailure (pause|retry|restart-fresh) controls recovery from step failures. Additional fields: maxRetries (default 3), maxContinuations (default 10), retryBackoff (linear|exponential). Without a resilience policy, execution pauses at step limits and failures (safe default)."
+      },
+      {
+        "element_name": "prepare_handoff",
+        "endpoint": "EXECUTE",
+        "description": "Serialize goal progress into a portable handoff block for session transfer"
+      },
+      {
+        "element_name": "resume_from_handoff",
+        "endpoint": "EXECUTE",
+        "description": "Resume agent execution from a handoff block with integrity validation"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #15.

Second walking-skeleton demo. DollhouseMCP speaks MCP-AQL natively, so the bridge talks straight to its `mcp_aql_*` tools — no adapter, no codegen, just a config entry.

## What changed

- **`examples/mcpaql.config.example.json`** — direct-mode dollhouse + a local-path github adapter placeholder. README walkthrough explains both shapes and shows the adapter-mode equivalent of the dollhouse block.
- **`scripts/smoke-dollhouse.mjs` + `npm run smoke:dollhouse`** — manual harness that spawns `@dollhousemcp/mcp-server` via `npx`, calls `read/introspect`, prints the operations list. Not CI-gated to avoid pinning pi-bridge's release cadence to dollhouse's.
- **`test/fixtures/dollhouse-introspect.json`** — captured response from `@dollhousemcp/mcp-server@2.0.32`.
- **`test/conformance-dollhouse.test.mjs`** — asserts the discriminated-response envelope passes the operation-result schema, AND that strict introspection-response validation currently fails because dollhouse's `OperationInfo` uses `element_name` instead of the spec's `name`. Two assertions together pin the known conformance gap (#23) — when DollhouseMCP closes it, the strict-failure assertion fails noisily and signals "refresh fixture, flip assertion."
- **`test/config.test.mjs`** — explicit tests that `examples/mcpaql.config.example.json` parses against `MCPAQL_CONFIG_SCHEMA` and that the README's documented dollhouse direct-mode shape resolves to `kind=direct`. Catches drift between docs and loader.
- **README** — "Quick start with DollhouseMCP" section + adapter-mode equivalent + known-conformance-gaps callout.

## Demo proof — live `read/introspect` against `@dollhousemcp/mcp-server@2.0.32`

`npm run smoke:dollhouse` produced a 76-operation introspection response. CRUDE breakdown:

| Endpoint | Count |
|---|---:|
| CREATE | 15 |
| READ | 48 |
| UPDATE | 2 |
| DELETE | 3 |
| EXECUTE | 8 |

Truncated sample (full fixture in `test/fixtures/dollhouse-introspect.json`):

```json
{
  "success": true,
  "data": {
    "operations": [
      { "element_name": "addEntry", "endpoint": "CREATE", "description": "Add a new entry to a memory element" },
      { "element_name": "create_element", "endpoint": "CREATE", "description": "Create a new element of any type. Note: Gatekeeper may return a confirmation prompt instead of creating immediately — use confirm_operation to approve, then retry." },
      { "element_name": "list_elements", "endpoint": "READ", "description": "List elements with pagination, filtering, sorting, and aggregation. ..." },
      { "element_name": "introspect", "endpoint": "READ", "description": "Query available operations, types, and element format specs for discovery" },
      { "element_name": "edit_element", "endpoint": "UPDATE", "description": "Edit an element using GraphQL-aligned nested input objects" },
      { "element_name": "delete_element", "endpoint": "DELETE", "description": "Delete an element" },
      { "element_name": "execute_agent", "endpoint": "EXECUTE", "description": "Start execution of an agent. ..." }
    ]
  }
}
```

## Conformance gaps observed

- `OperationInfo` uses `element_name` instead of the spec's `name` — fails strict `additionalProperties: false` and the `required: ["name", ...]` constraint. Pinned by the new conformance test; tracked by #23.
- No `_protocol` metadata on `OperationsListData` — spec marks it optional, so this isn't a hard violation, but the absence is noteworthy for future capability negotiation.
- `introspect` itself appears twice in the operations list (verbatim duplicate). Likely a separate dollhouse-side bug; not blocking.

Filing these as a follow-up rather than blocking this PR, per the issue's "out of scope" note.

## Tests

`npm test` → **60/60** passing locally (was 56 + 4 new):
- `examples/mcpaql.config.example.json parses against MCPAQL_CONFIG_SCHEMA`
- `dollhouse direct-mode shape from the README parses as documented`
- `dollhouse introspection envelope conforms to operation-result`
- `dollhouse introspection currently fails strict introspection-response (documents gap)`

## Test plan

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] `npm run smoke:dollhouse` runs against live `@dollhousemcp/mcp-server@2.0.32` and exits 0 with non-empty operations array
- [ ] @claude review pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)